### PR TITLE
Fix `workflows/update-french.yaml` (`Cannot read properties of undefined (reading 'number')`)

### DIFF
--- a/.github/workflows/update-french.yaml
+++ b/.github/workflows/update-french.yaml
@@ -53,7 +53,7 @@ jobs:
 
     - name: Create Pull Request
       if: github.ref == 'refs/heads/main'
-      uses: peter-evans/create-pull-request@v5
+      uses: peter-evans/create-pull-request@v6
       env:
         GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
       with:


### PR DESCRIPTION
Update `peter-evans/create-pull-request` action to the `v6` tag due to GitHub API breaking changes

Fixed in [v6.0.1](https://github.com/peter-evans/create-pull-request/releases/tag/v6.0.1)
PR: peter-evans/create-pull-request#2790