### PR TITLE
Fix: Escape special characters in INI file content before parsing

### DIFF
--- a/tools/ini-utils/examples/reference.ini
+++ b/tools/ini-utils/examples/reference.ini
@@ -4,6 +4,8 @@ good_placeholder=Cluster Factor (~ItemModifierMethod(value)%)
 good_multiple_placeholder=NOW HIRING FOR IMMEDIATE START\n\nLooking for ~mission(EscortType) to guard a ~mission(Client) while they travel to ~mission(EscortNum). ~mission(Danger)Payment will be certified through ~mission(Contractor) and transferred upon completion.
 good_placeholder_case_insensitive=Cluster Factor (~ItemModifierMethod(Value)%)
 good_pipe_placeholder=You need to go there: ~mission(Destination|Address)
+good_singleton_comment=Hey Me ~mission(TargetName)
+good_number_comment=Next mission ~mission(TargetName)
 
 bad_variable=Forces Remaining %ls
 bad_percent_placeholder=ERROR - %s (CODE %i)\n%s

--- a/tools/ini-utils/examples/source.ini
+++ b/tools/ini-utils/examples/source.ini
@@ -4,6 +4,8 @@ good_placeholder=facteur de grappe (~ItemModifierMethod(value)%)
 good_multiple_placeholder=RECRUTEMENT URGENT\n\nRecherchons ~mission(EscortType) pour protéger ~mission(Client) durant leur voyage vers ~mission(EscortNum).  Le paiement de la ~mission(Danger)sera validé par ~mission(Contractor) et transféré une fois la tâche accomplie.
 good_placeholder_case_insensitive=facteur de grappe (~itemModifiermethod(value)%)
 good_pipe_placeholder=You need to go there: ~mission(Destination|Address)
+good_singleton_comment=Salut; moi ~mission(TargetName);
+good_number_comment=Prochaine mission: #~mission(TargetName)#
 
 bad_variable=Forces restantes %lsX
 bad_percent_placeholder=ERREUR - %S (CODE %i)\n%t

--- a/tools/ini-utils/src/shared/helpers/ini.helper.ts
+++ b/tools/ini-utils/src/shared/helpers/ini.helper.ts
@@ -17,10 +17,14 @@ export class IniHelper
   {
     console.log(`Loading file ${filePath}`);
 
-    const fileContent = fs.readFileSync(filePath, 'utf-8');
-    return {
+    const fileContent = fs.readFileSync(filePath, 'utf-8')
+      .replace(/([\S] *);/g, '$1\\;')  // escape semicolon
+      .replace(/([\S] *)#/g, '$1\\#'); // escape hash
+
+    const parsed = ini.parse(fileContent);
+      return {
       path   : filePath,
-      content: ini.parse(fileContent)
+      content: parsed
     };
   }
 


### PR DESCRIPTION
Add the functionality to escape special characters in INI file content before parsing. This ensures that semicolons and hashes are properly handled and do not interfere with the parsing process.

#310 