### PR TITLE
Fix double escapement of semicolons and hash characters

### DIFF
--- a/tools/ini-utils/examples/source.ini
+++ b/tools/ini-utils/examples/source.ini
@@ -5,7 +5,7 @@ good_multiple_placeholder=RECRUTEMENT URGENT\n\nRecherchons ~mission(EscortType)
 good_placeholder_case_insensitive=facteur de grappe (~itemModifiermethod(value)%)
 good_pipe_placeholder=You need to go there: ~mission(Destination|Address)
 good_singleton_comment=Salut; moi ~mission(TargetName);
-good_number_comment=Prochaine mission: #~mission(TargetName)#
+good_number_comment=Prochaine mission: \# at #~mission(TargetName)
 
 bad_variable=Forces restantes %lsX
 bad_percent_placeholder=ERREUR - %S (CODE %i)\n%t

--- a/tools/ini-utils/src/shared/helpers/ini.helper.ts
+++ b/tools/ini-utils/src/shared/helpers/ini.helper.ts
@@ -18,11 +18,10 @@ export class IniHelper
     console.log(`Loading file ${filePath}`);
 
     const fileContent = fs.readFileSync(filePath, 'utf-8')
-      .replace(/([\S] *);/g, '$1\\;')  // escape semicolon
-      .replace(/([\S] *)#/g, '$1\\#'); // escape hash
+      .replace(/([\S] *)(?<!\\)([;#])/g, '$1\\$2')  // escape semicolon and hash
 
     const parsed = ini.parse(fileContent);
-      return {
+    return {
       path   : filePath,
       content: parsed
     };


### PR DESCRIPTION
Fixes an issue where semicolons and hash characters were being double-escaped in certain scenarios. The problem has been resolved by updating the regular expression used for escaping to exclude characters that are already escaped.