### PR TITLE
Update file paths in validation command

### DIFF
--- a/tools/ini-utils/README.md
+++ b/tools/ini-utils/README.md
@@ -44,5 +44,5 @@ To validate INI files, use the `validate` command. This command checks if all en
 Example:
 
   ```sh
-  node ./dist/src/index.js validate data/Localization/english/global.ini data/Localization/french_(france)/global.ini
+  node ./dist/src/index.js validate ../../data/Localization/english/global.ini ../../data/Localization/french_(france)/global.ini
   ```


### PR DESCRIPTION
This pull request includes a small change to the `tools/ini-utils/README.md` file. The change updates the example command to use relative paths for the INI files.

* [`tools/ini-utils/README.md`](diffhunk://#diff-ed9fb118a314394cb77f7fdac15e13d43cfcd3270c2e3d19921f5e0f641278d9L47-R47): Updated the example command to use relative paths for the INI files.