### PR TITLE
Remove GITHUB_TOKEN and create a draft PR instead

### DIFF
--- a/.github/workflows/update-french.yaml
+++ b/.github/workflows/update-french.yaml
@@ -54,13 +54,12 @@ jobs:
     - name: Create Pull Request
       if: github.ref == 'refs/heads/main'
       uses: peter-evans/create-pull-request@v6
-      env:
-        GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
       with:
         add-paths: data/Localization/french_(france)/global.ini
         commit-message: Update French localization 🇫🇷
         branch: feature/update-french
-        delete-branch: true
         title: Update French localization 🇫🇷
         labels: french
+        delete-branch: true
         assignees: Dymerz
+        draft: always-true


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow for updating French localization. The most important changes involve modifying the configuration for creating pull requests.

Changes to GitHub Actions workflow:

* [`.github/workflows/update-french.yaml`](diffhunk://#diff-953feb45a476997954829d5e11b55cbbcc55a80d1af0f3802fc14bc0f487f219L57-R65): Moved the `delete-branch` setting from the `env` section to the `with` section and added a new `draft` setting to always create pull requests as drafts.