### PR TITLE
Add draft flag to build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,4 +39,5 @@ jobs:
           data/*.zip
           tools/*.cmd
           tools/*.ps1
+        draft: true
 


### PR DESCRIPTION
Mark the workflow as a draft to prevent it from running automatically.