### PR TITLE
Install localistion.cmd

### DIFF
--- a/tools/install_localization.cmd
+++ b/tools/install_localization.cmd
@@ -41,7 +41,6 @@ echo 9. Polish - Poland
 echo 10. Portuguese - Brazil
 echo 11. Spanish - Latin America
 echo 12. Spanish - Spain
-REM echo 13. Lithuanian - Lithuania
 
 echo Enter the number of the language you want to select.
 :LanguageInput

--- a/tools/install_localization.cmd
+++ b/tools/install_localization.cmd
@@ -41,6 +41,7 @@ echo 9. Polish - Poland
 echo 10. Portuguese - Brazil
 echo 11. Spanish - Latin America
 echo 12. Spanish - Spain
+REM echo 13. Lithuanian - Lithuania
 
 echo Enter the number of the language you want to select.
 :LanguageInput
@@ -88,7 +89,7 @@ set "language_line_audio=g_languageAudio = english"
 
 if not exist "../user.cfg" (
     echo !language_line! > ../user.cfg
-    echo !language_line_audio! > ../user.cfg
+    echo !language_line_audio! >> ../user.cfg
 ) else (
     set "foundLanguage=0"
     set "foundLanguageAudio=0"


### PR DESCRIPTION
Fixed that if the user.cfg does not exist the line for example "g_language = german_(germany)" got overwritten with the line "g_languageAudio = english"
