### PR TITLE
Update validate-global-ini.yaml workflow to trigger on pull request ready_for_review events

### DIFF
--- a/.github/workflows/validate-global-ini.yaml
+++ b/.github/workflows/validate-global-ini.yaml
@@ -7,6 +7,11 @@ on:
       - main
       - ptu
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
     branches:
       - main
       - ptu


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/validate-global-ini.yaml` file. The change specifies additional pull request types to trigger the workflow.

Changes to workflow triggers:

* [`.github/workflows/validate-global-ini.yaml`](diffhunk://#diff-38b7ea30aecfc2d2077eaf8122ca44ae1a333d162939fcbe4bc18aa564db19b1R10-R14): Added `opened`, `synchronize`, `reopened`, and `ready_for_review` pull request types to the `types` section under `pull_request`.