### PR TITLE
Fix INI file reading and escaping functionality in IniHelper class

### DIFF
--- a/tools/ini-utils/src/shared/helpers/ini.helper.ts
+++ b/tools/ini-utils/src/shared/helpers/ini.helper.ts
@@ -13,6 +13,11 @@ export class IniHelper
     fs.writeFileSync(path, data, options);
   }
 
+  public static readFileSync(path: string): string
+  {
+    return fs.readFileSync(path, 'utf-8');
+  }
+
   /**
    * Load an INI file and return its content as an object
    * @param filePath
@@ -20,10 +25,10 @@ export class IniHelper
   */
   public static loadFile(filePath: string): Ini
   {
-    const fileContent = fs.readFileSync(filePath, 'utf-8')
-      .replace(/([\S] *)(?<!\\)([;#])/g, '$1\\$2')  // escape semicolon and hash
+    const fileContent = IniHelper.readFileSync(filePath);
+    const fileContentEscaped = IniHelper.escapeValues(fileContent);
 
-    const parsed = ini.parse(fileContent);
+    const parsed = ini.parse(fileContentEscaped);
     return {
       path   : filePath,
       content: parsed
@@ -38,5 +43,19 @@ export class IniHelper
   public static writeFile(file: Ini): void
   {
     IniHelper.writeFileSync(file.path, '\ufeff'+ini.stringify(file.content), { encoding: 'utf-8',  });
+  }
+
+  /**
+   * Escape semicolon and hash from values in INI file
+   * @param content
+   * @returns
+   */
+  private static escapeValues(content: string): string
+  {
+    return content.replace(/^([^=\r\n]+)=(.*)$/gm, (_, key, value) =>
+    {
+      const escapedValue = value.replace(/([#;\\])/g, '\\$1');
+      return `${key}=${escapedValue}`;
+    });
   }
 }

--- a/tools/ini-utils/test/commands/validate-run-internal.spec.ts
+++ b/tools/ini-utils/test/commands/validate-run-internal.spec.ts
@@ -75,23 +75,58 @@ describe('ValidateCommand.runInternal', () =>
 
   it('should validate value with semi-colon', () =>
   {
-    const referenceData = makeIniFromKey(reference, 'good_semi_colon_comment');
-    const sourceData = makeIniFromKey(source, 'good_semi_colon_comment');
+    const referenceData = makeIniFromKey(reference, 'good_semi_colon');
+    const sourceData = makeIniFromKey(source, 'good_semi_colon');
 
     const result = validateIni(referenceData, sourceData);
-    assert.ok(result, 'semi-colon in value should be valid');
+    assert.ok(result, 'semi-colon in value should be escaped');
   });
 
-  it('should validate value with hashtag', () =>
+  it('should validate value with double semi-colon', () =>
   {
-    const referenceData = makeIniFromKey(reference, 'good_hashtag_comment');
-    const sourceData = makeIniFromKey(source, 'good_hashtag_comment');
+    const referenceData = makeIniFromKey(reference, 'good_double_semi_colon');
+    const sourceData = makeIniFromKey(source, 'good_double_semi_colon');
 
     const result = validateIni(referenceData, sourceData);
-    assert.ok(result, 'hashtag in value should be valid');
+    assert.ok(result, 'double semi-colon in value should be escaped');
   });
 
-  // TODO
+  it('should validate value with semi-colon escaped', () =>
+  {
+    const referenceData = makeIniFromKey(reference, 'good_semi_colon_escaped');
+    const sourceData = makeIniFromKey(source, 'good_semi_colon_escaped');
+
+    const result = validateIni(referenceData, sourceData);
+    assert.ok(result, 'escaped semi-colon in value should be escaped');
+  });
+
+  it('should validate value with hash', () =>
+  {
+    const referenceData = makeIniFromKey(reference, 'good_hash');
+    const sourceData = makeIniFromKey(source, 'good_hash');
+
+    const result = validateIni(referenceData, sourceData);
+    assert.ok(result, 'hash in value should be escaped');
+  });
+
+  it('should validate value with double hash', () =>
+    {
+      const referenceData = makeIniFromKey(reference, 'good_double_hash');
+      const sourceData = makeIniFromKey(source, 'good_double_hash');
+
+      const result = validateIni(referenceData, sourceData);
+      assert.ok(result, 'double hash in value should be escaped');
+    });
+
+  it('should validate value with hash escaped', () =>
+  {
+    const referenceData = makeIniFromKey(reference, 'good_hash_escaped');
+    const sourceData = makeIniFromKey(source, 'good_hash_escaped');
+
+    const result = validateIni(referenceData, sourceData);
+    assert.ok(result, 'escaped hash in value should be escaped');
+  });
+
   it('should not validate misspelled percent placeholder', () =>
   {
     const referenceData = makeIniFromKey(reference, 'bad_percent_placeholder1');
@@ -149,7 +184,7 @@ describe('ValidateCommand.runInternal', () =>
   it('should not validate bad key', () =>
   {
     const referenceData = makeIniFromKey(reference, 'bad_key');
-    const sourceData = makeIniFromKey(source, 'bad_key');
+    const sourceData = makeIniFromKey(source, 'mauvaise_cle');
 
     const result = validateIni(referenceData, sourceData);
     assert.ok(!result, 'bad key should not be valid');

--- a/tools/ini-utils/test/fixtures/reference.ini
+++ b/tools/ini-utils/test/fixtures/reference.ini
@@ -5,8 +5,12 @@ good_placeholder=Cluster Factor (~ItemModifierMethod(value)%)
 good_multiple_placeholder=NOW HIRING FOR IMMEDIATE START\n\nLooking for ~mission(EscortType) to guard a ~mission(Client) while they travel to ~mission(EscortNum). ~mission(Danger)Payment will be certified through ~mission(Contractor) and transferred upon completion.
 good_placeholder_case_insensitive=Cluster Factor (~ItemModifierMethod(Value)%)
 good_pipe_placeholder=You need to go there: ~mission(Destination|Address)
-good_semi_colon_comment=Hey Me ~mission(TargetName)
-good_hashtag_comment=Next mission ~mission(TargetName)
+good_semi_colon=Hey Me ~mission(TargetName)
+good_double_semi_colon=Hey Me ~mission(TargetName)
+good_semi_colon_escaped=Hey Me ~mission(TargetName)
+good_hash=Next mission ~mission(TargetName)
+good_double_hash=You must go to ~mission(Location) and take the #~mission(Item)
+good_hash_escaped=Next mission ~mission(TargetName)
 
 bad_percent_placeholder1=ERREUR - %S (CODE %i)\n%s
 bad_percent_placeholder2=ERROR - %s (CODE %i)\n%s

--- a/tools/ini-utils/test/fixtures/source.ini
+++ b/tools/ini-utils/test/fixtures/source.ini
@@ -4,8 +4,12 @@ good_placeholder=facteur de grappe (~ItemModifierMethod(value)%)
 good_multiple_placeholder=RECRUTEMENT URGENT\n\nRecherchons ~mission(EscortType) pour protéger ~mission(Client) durant leur voyage vers ~mission(EscortNum).  Le paiement de la ~mission(Danger)sera validé par ~mission(Contractor) et transféré une fois la tâche accomplie.
 good_placeholder_case_insensitive=facteur de grappe (~itemModifiermethod(value)%)
 good_pipe_placeholder=You need to go there: ~mission(Destination|Address)
-good_semi_colon_comment=Salut; moi ~mission(TargetName);
-good_hashtag_comment=Prochaine mission: \# at #~mission(TargetName)
+good_semi_colon=Salut; moi ~mission(TargetName);
+good_double_semi_colon=Salut;; moi ~mission(TargetName);
+good_semi_colon_escaped=Salut\; moi ~mission(TargetName);
+good_hash=Prochaine mission #~mission(TargetName)
+good_double_hash=Vous devez aller à ~mission(Location) et prendre l'objet ##~mission(Item)
+good_hash_escaped=Prochaine mission: \# at #~mission(TargetName)
 
 bad_percent_placeholder1=ERREUR - %S (CODE %i)\n%sX
 bad_percent_placeholder2=ERREUR - %S (CODE %i)\n%t

--- a/tools/ini-utils/test/utils.ts
+++ b/tools/ini-utils/test/utils.ts
@@ -27,6 +27,9 @@ export const makeIniFromKey = (file: Ini, key: string): Ini =>
       return obj;
     }, {} as any);
 
+  if(Object.keys(content).length === 0)
+    throw new Error(`Key '${key}' not found in file ${file.path}`);
+
   return {
     path: file.path,
     content


### PR DESCRIPTION
This pull request introduces several enhancements and bug fixes to the `IniHelper` class and its associated test suite. The changes primarily focus on improving the handling of special characters in INI files and enhancing test coverage.

### Enhancements to `IniHelper`:

* Added a new method `readFileSync` to read file content.
* Introduced a private method `escapeValues` to escape semicolons, hashes, and backslashes in INI file values.

### Updates to Test Suite:

* Modified existing tests to validate the escaping of special characters like semicolons and hashes.
* Added new test cases to cover scenarios with escaped semicolons, hashes, double semicolons, and double hashes.
* Changed test data in `reference.ini` and `source.ini` to align with the new escape logic. [[1]](diffhunk://#diff-79d53c62ef21f98fa0472c1748a200d9730bcbde1f166cdabd175a7d96bba188L8-R13) [[2]](diffhunk://#diff-83fb7d6e6a63e911390ef0664191d0c16c893be8551ffada2dbed0a051199a05L7-R12)
* Enhanced the `makeIniFromKey` utility function to throw an error if a key is not found in the INI file.