### PR TITLE
Fix/validate global ini - validate entries

### DIFF
--- a/.github/workflows/validate-global-ini.yaml
+++ b/.github/workflows/validate-global-ini.yaml
@@ -107,4 +107,4 @@ jobs:
       run: npm run build
 
     - name: Validate key/value pairs
-      run: node ./tools/ini-utils/dist/src/index.js validate --ci "$GITHUB_WORKSPACE/data/Localization/english/global.ini" "${{ needs.prepare.outputs.changed-files }}"
+      run: node ./tools/ini-utils/dist/src/index.js validate --ci "$GITHUB_WORKSPACE/data/Localization/english/global.ini" ${{ needs.prepare.outputs.changed-files }}


### PR DESCRIPTION
This pull request includes a minor change to the `.github/workflows/validate-global-ini.yaml` file. The change involves modifying the syntax for passing the `changed-files` output from the `prepare` job to the `validate` script.

* [`.github/workflows/validate-global-ini.yaml`](diffhunk://#diff-38b7ea30aecfc2d2077eaf8122ca44ae1a333d162939fcbe4bc18aa564db19b1L110-R110): Corrected the syntax for the `changed-files` output in the `validate` step.