### PR TITLE
Update French language badge version to 4.0.2 in multiple README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 | Language                 | Supported | Source |
 |--------------------------|-----------|--------|
 | English                  | ![Static Badge](https://img.shields.io/badge/4.1.0-LIVE-brightgreen) | Imported from game files |
-| French - France          | ![Static Badge](https://img.shields.io/badge/4.1.0-LIVE-brightgreen) | Generated from [circuspes.fr](https://traduction.circuspes.fr) and [SPEED0U/StarCitizenFrenchTranslation](https://github.com/SPEED0U/StarCitizenFrenchTranslation) |
+| French - France          | ![Static Badge](https://img.shields.io/badge/4.0.2-LIVE-brightgreen) | Generated from [circuspes.fr](https://traduction.circuspes.fr) and [SPEED0U/StarCitizenFrenchTranslation](https://github.com/SPEED0U/StarCitizenFrenchTranslation) |
 | German - Germany         | ![Static Badge](https://img.shields.io/badge/4.1.0-LIVE-brightgreen) | Here |
 | Portuguese - Brazil      | ![Static Badge](https://img.shields.io/badge/4.1.0-LIVE-brightgreen) | Here |
 | Italian - Italy          | ![Static Badge](https://img.shields.io/badge/3.24.1-LIVE-yellow) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) and [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |

--- a/README_de.md
+++ b/README_de.md
@@ -29,7 +29,7 @@
 | Sprache                 | Unterstützt | Quelle |
 |--------------------------|-------------|--------|
 | Englisch                | ![Static Badge](https://img.shields.io/badge/4.1.0-LIVE-brightgreen) | Aus Spieldateien importiert |
-| Französisch - Frankreich | ![Static Badge](https://img.shields.io/badge/4.1.0-LIVE-brightgreen) | Generiert von [circuspes.fr](https://traduction.circuspes.fr) und [SPEED0U/StarCitizenFrenchTranslation](https://github.com/SPEED0U/StarCitizenFrenchTranslation) |
+| Französisch - Frankreich | ![Static Badge](https://img.shields.io/badge/4.0.2-LIVE-brightgreen) | Generiert von [circuspes.fr](https://traduction.circuspes.fr) und [SPEED0U/StarCitizenFrenchTranslation](https://github.com/SPEED0U/StarCitizenFrenchTranslation) |
 | Deutsch - Deutschland   | ![Static Badge](https://img.shields.io/badge/4.1.0-LIVE-brightgreen) | Hier |
 | Portugiesisch - Brasilien| ![Static Badge](https://img.shields.io/badge/4.1.0-LIVE-brightgreen) | Hier |
 | Italienisch - Italien   | ![Static Badge](https://img.shields.io/badge/3.24.1-LIVE-yellow) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) und [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |

--- a/README_es.md
+++ b/README_es.md
@@ -30,7 +30,7 @@
 | Idioma                  | Soportado   | Fuente |
 |--------------------------|-------------|--------|
 | Inglés                  | ![Static Badge](https://img.shields.io/badge/4.1.0-LIVE-brightgreen) | Importado de archivos del juego |
-| Francés - Francia       | ![Static Badge](https://img.shields.io/badge/4.1.0-LIVE-brightgreen) | Generado desde [circuspes.fr](https://traduction.circuspes.fr) y [SPEED0U/StarCitizenFrenchTranslation](https://github.com/SPEED0U/StarCitizenFrenchTranslation) |
+| Francés - Francia       | ![Static Badge](https://img.shields.io/badge/4.0.2-LIVE-brightgreen) | Generado desde [circuspes.fr](https://traduction.circuspes.fr) y [SPEED0U/StarCitizenFrenchTranslation](https://github.com/SPEED0U/StarCitizenFrenchTranslation) |
 | Alemán - Alemania       | ![Static Badge](https://img.shields.io/badge/4.1.0-LIVE-brightgreen) | Aquí |
 | Portugués - Brasil      | ![Static Badge](https://img.shields.io/badge/4.1.0-LIVE-brightgreen) | Aquí |
 | Italiano - Italia       | ![Static Badge](https://img.shields.io/badge/3.24.1-LIVE-yellow) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) y [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |

--- a/README_fr.md
+++ b/README_fr.md
@@ -30,7 +30,7 @@
 | Langue                  | Pris en charge | Source |
 |--------------------------|----------------|--------|
 | Anglais                 | ![Static Badge](https://img.shields.io/badge/4.1.0-LIVE-LIVE-brightgreen) | Importé des fichiers du jeu |
-| Français - France       | ![Static Badge](https://img.shields.io/badge/4.1.0-LIVE-brightgreen) | Généré depuis [circuspes.fr](https://traduction.circuspes.fr) et [SPEED0U/StarCitizenFrenchTranslation](https://github.com/SPEED0U/StarCitizenFrenchTranslation) |
+| Français - France       | ![Static Badge](https://img.shields.io/badge/4.0.2-LIVE-brightgreen) | Généré depuis [circuspes.fr](https://traduction.circuspes.fr) et [SPEED0U/StarCitizenFrenchTranslation](https://github.com/SPEED0U/StarCitizenFrenchTranslation) |
 | Allemand - Allemagne    | ![Static Badge](https://img.shields.io/badge/4.1.0-LIVE-brightgreen) | Ici |
 | Portugais - Brésil      | ![Static Badge](https://img.shields.io/badge/4.1.0-LIVE-brightgreen) | Ici |
 | Italien - Italie        | ![Static Badge](https://img.shields.io/badge/3.24.1-LIVE-yellow) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) et [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |

--- a/README_it.md
+++ b/README_it.md
@@ -30,7 +30,7 @@
 | Lingua                  | Supportato | Fonte |
 |--------------------------|------------|-------|
 | Inglese                 | ![Static Badge](https://img.shields.io/badge/4.1.0-LIVE-brightgreen) | Importato dai file di gioco |
-| Francese - Francia      | ![Static Badge](https://img.shields.io/badge/4.1.0-LIVE-brightgreen) | Generato da [circuspes.fr](https://traduction.circuspes.fr) e [SPEED0U/StarCitizenFrenchTranslation](https://github.com/SPEED0U/StarCitizenFrenchTranslation) |
+| Francese - Francia      | ![Static Badge](https://img.shields.io/badge/4.0.2-LIVE-brightgreen) | Generato da [circuspes.fr](https://traduction.circuspes.fr) e [SPEED0U/StarCitizenFrenchTranslation](https://github.com/SPEED0U/StarCitizenFrenchTranslation) |
 | Tedesco - Germania      | ![Static Badge](https://img.shields.io/badge/4.1.0-LIVE-brightgreen) | Qui |
 | Portoghese - Brasile    | ![Static Badge](https://img.shields.io/badge/4.1.0-LIVE-brightgreen) | Qui |
 | Italiano - Italia       | ![Static Badge](https://img.shields.io/badge/3.24.1-LIVE-yellow) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) e [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |

--- a/README_ptbr.md
+++ b/README_ptbr.md
@@ -29,7 +29,7 @@
 | Idioma                  | Suportado | Fonte |
 |--------------------------|-----------|-------|
 | Inglês                  | ![Static Badge](https://img.shields.io/badge/4.1.0-LIVE-brightgreen) | Importado dos arquivos do jogo |
-| Francês - França        | ![Static Badge](https://img.shields.io/badge/4.1.0-LIVE-brightgreen) | Gerado de [circuspes.fr](https://traduction.circuspes.fr) e [SPEED0U/StarCitizenFrenchTranslation](https://github.com/SPEED0U/StarCitizenFrenchTranslation) |
+| Francês - França        | ![Static Badge](https://img.shields.io/badge/4.0.2-LIVE-brightgreen) | Gerado de [circuspes.fr](https://traduction.circuspes.fr) e [SPEED0U/StarCitizenFrenchTranslation](https://github.com/SPEED0U/StarCitizenFrenchTranslation) |
 | Alemão - Alemanha       | ![Static Badge](https://img.shields.io/badge/4.1.0-LIVE-brightgreen) | Aqui |
 | Português - Brasil      | ![Static Badge](https://img.shields.io/badge/4.1.0-LIVE-brightgreen) | Aqui |
 | Italiano - Itália       | ![Static Badge](https://img.shields.io/badge/3.24.1-LIVE-yellow) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) e [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |


### PR DESCRIPTION
Update the French language badge across various README files to reflect the new version 4.0.2.