### PR TITLE
Feature/improve ini utils cli usage

### DIFF
--- a/.github/workflows/ini-utils-ci.yaml
+++ b/.github/workflows/ini-utils-ci.yaml
@@ -96,6 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
       id-token: write
 
     steps:

--- a/LICENSE
+++ b/LICENSE
@@ -1,121 +1,21 @@
-Creative Commons Legal Code
+MIT License
 
-CC0 1.0 Universal
+Copyright (c) 2025 Corentin Urbain "Dymerz"
 
-    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
-    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
-    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
-    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
-    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
-    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
-    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
-    HEREUNDER.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-Statement of Purpose
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-The laws of most jurisdictions throughout the world automatically confer
-exclusive Copyright and Related Rights (defined below) upon the creator
-and subsequent owner(s) (each and all, an "owner") of an original work of
-authorship and/or a database (each, a "Work").
-
-Certain owners wish to permanently relinquish those rights to a Work for
-the purpose of contributing to a commons of creative, cultural and
-scientific works ("Commons") that the public can reliably and without fear
-of later claims of infringement build upon, modify, incorporate in other
-works, reuse and redistribute as freely as possible in any form whatsoever
-and for any purposes, including without limitation commercial purposes.
-These owners may contribute to the Commons to promote the ideal of a free
-culture and the further production of creative, cultural and scientific
-works, or to gain reputation or greater distribution for their Work in
-part through the use and efforts of others.
-
-For these and/or other purposes and motivations, and without any
-expectation of additional consideration or compensation, the person
-associating CC0 with a Work (the "Affirmer"), to the extent that he or she
-is an owner of Copyright and Related Rights in the Work, voluntarily
-elects to apply CC0 to the Work and publicly distribute the Work under its
-terms, with knowledge of his or her Copyright and Related Rights in the
-Work and the meaning and intended legal effect of CC0 on those rights.
-
-1. Copyright and Related Rights. A Work made available under CC0 may be
-protected by copyright and related or neighboring rights ("Copyright and
-Related Rights"). Copyright and Related Rights include, but are not
-limited to, the following:
-
-  i. the right to reproduce, adapt, distribute, perform, display,
-     communicate, and translate a Work;
- ii. moral rights retained by the original author(s) and/or performer(s);
-iii. publicity and privacy rights pertaining to a person's image or
-     likeness depicted in a Work;
- iv. rights protecting against unfair competition in regards to a Work,
-     subject to the limitations in paragraph 4(a), below;
-  v. rights protecting the extraction, dissemination, use and reuse of data
-     in a Work;
- vi. database rights (such as those arising under Directive 96/9/EC of the
-     European Parliament and of the Council of 11 March 1996 on the legal
-     protection of databases, and under any national implementation
-     thereof, including any amended or successor version of such
-     directive); and
-vii. other similar, equivalent or corresponding rights throughout the
-     world based on applicable law or treaty, and any national
-     implementations thereof.
-
-2. Waiver. To the greatest extent permitted by, but not in contravention
-of, applicable law, Affirmer hereby overtly, fully, permanently,
-irrevocably and unconditionally waives, abandons, and surrenders all of
-Affirmer's Copyright and Related Rights and associated claims and causes
-of action, whether now known or unknown (including existing as well as
-future claims and causes of action), in the Work (i) in all territories
-worldwide, (ii) for the maximum duration provided by applicable law or
-treaty (including future time extensions), (iii) in any current or future
-medium and for any number of copies, and (iv) for any purpose whatsoever,
-including without limitation commercial, advertising or promotional
-purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
-member of the public at large and to the detriment of Affirmer's heirs and
-successors, fully intending that such Waiver shall not be subject to
-revocation, rescission, cancellation, termination, or any other legal or
-equitable action to disrupt the quiet enjoyment of the Work by the public
-as contemplated by Affirmer's express Statement of Purpose.
-
-3. Public License Fallback. Should any part of the Waiver for any reason
-be judged legally invalid or ineffective under applicable law, then the
-Waiver shall be preserved to the maximum extent permitted taking into
-account Affirmer's express Statement of Purpose. In addition, to the
-extent the Waiver is so judged Affirmer hereby grants to each affected
-person a royalty-free, non transferable, non sublicensable, non exclusive,
-irrevocable and unconditional license to exercise Affirmer's Copyright and
-Related Rights in the Work (i) in all territories worldwide, (ii) for the
-maximum duration provided by applicable law or treaty (including future
-time extensions), (iii) in any current or future medium and for any number
-of copies, and (iv) for any purpose whatsoever, including without
-limitation commercial, advertising or promotional purposes (the
-"License"). The License shall be deemed effective as of the date CC0 was
-applied by Affirmer to the Work. Should any part of the License for any
-reason be judged legally invalid or ineffective under applicable law, such
-partial invalidity or ineffectiveness shall not invalidate the remainder
-of the License, and in such case Affirmer hereby affirms that he or she
-will not (i) exercise any of his or her remaining Copyright and Related
-Rights in the Work or (ii) assert any associated claims and causes of
-action with respect to the Work, in either case contrary to Affirmer's
-express Statement of Purpose.
-
-4. Limitations and Disclaimers.
-
- a. No trademark or patent rights held by Affirmer are waived, abandoned,
-    surrendered, licensed or otherwise affected by this document.
- b. Affirmer offers the Work as-is and makes no representations or
-    warranties of any kind concerning the Work, express, implied,
-    statutory or otherwise, including without limitation warranties of
-    title, merchantability, fitness for a particular purpose, non
-    infringement, or the absence of latent or other defects, accuracy, or
-    the present or absence of errors, whether or not discoverable, all to
-    the greatest extent permissible under applicable law.
- c. Affirmer disclaims responsibility for clearing rights of other persons
-    that may apply to the Work or any use thereof, including without
-    limitation any person's Copyright and Related Rights in the Work.
-    Further, Affirmer disclaims responsibility for obtaining any necessary
-    consents, permissions or other rights required for any use of the
-    Work.
- d. Affirmer understands and acknowledges that Creative Commons is not a
-    party to this document and has no duty or obligation with respect to
-    this CC0 or use of the Work.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tools/ini-utils/.mocharc.json
+++ b/tools/ini-utils/.mocharc.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/mocharc",
-  "extension": ["ts"],
+  "extension": [
+    "ts"
+  ],
   "spec": "test/**/*.spec.ts",
   "recursive": true,
-  "timeout": 9999999
+  "timeout": 500
 }

--- a/tools/ini-utils/README.md
+++ b/tools/ini-utils/README.md
@@ -1,115 +1,147 @@
-# ini-utils
+# StarCitizen INI Utils
 
-`@dymerz/starcitizen-ini-utils` is a utility tool for working with Star Citizen INI localization files. It provides commands to merge and validate INI files.
+[![INI Utils - Build and Publish](https://github.com/Dymerz/StarCitizen-Localization/actions/workflows/ini-utils-ci.yaml/badge.svg)](https://github.com/Dymerz/StarCitizen-Localization/actions/workflows/ini-utils-ci.yaml)
+[![npm version](https://img.shields.io/npm/v/@dymerz/starcitizen-ini-utils.svg)](https://www.npmjs.com/package/@dymerz/starcitizen-ini-utils)
+[![Node.js Version](https://img.shields.io/node/v/@dymerz/starcitizen-ini-utils)](https://nodejs.org/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+
+## Overview
+
+`@dymerz/starcitizen-ini-utils` is a specialized utility tool designed for working with Star Citizen localization files in INI format. This tool offers commands to validate and merge INI files, making it easier to manage and maintain localization data.
+
+### Key Features
+
+- **Validation**: Check if all entries from a reference file exist in source files and verify placeholder consistency
+- **Merging**: Combine multiple INI files intelligently to create updated localization files
+- **Placeholder Validation**: Ensures that special placeholders (% and ~ format) match between reference and translated content
+- **CI/CD Integration**: Can be used in continuous integration workflows with the `--ci` flag
 
 ## Prerequisites
 
 - [Node.js](https://nodejs.org/) (version 18 or higher)
 - [npm](https://www.npmjs.com/)
 
-## Setup
+## Installation Options
 
-1. **Clone the repository:**
+### Option 1: Use directly with npx (No Installation Required)
 
-    ```sh
-    git clone https://github.com/Dymerz/StarCitizen-Localization.git
-    cd tools/ini-utils
-    ```
-
-2. **Install dependencies:**
-
-    ```sh
-    npm install
-    ```
-
-3. **Build the project:**
-
-    ```sh
-    npm run build
-    ```
-
-## Usage
-
-### Using with npx from GitHub Packages (Recommended)
-
-You can use this tool directly with npx from GitHub Packages:
+The easiest way to use this tool is directly with npx:
 
 ```sh
 npx @dymerz/starcitizen-ini-utils
 ```
 
-Or with a specific command:
+### Option 2: Install as a project dependency
+
+```sh
+npm install @dymerz/starcitizen-ini-utils --save-dev
+```
+
+### Option 3: Local development setup
+1. **Clone the repository:**
+
+  ```sh
+  git clone https://github.com/Dymerz/StarCitizen-Localization.git
+  cd tools/ini-utils
+  ```
+
+2. **Install dependencies:**
+
+  ```sh
+  npm install
+  ```
+
+3. **Build the project:**
+
+  ```sh
+  npm run build
+  ```
+
+4. **Run tests:**
+
+  ```sh
+  npm test
+  ```
+
+## Usage
+
+### Command: `validate`
+
+Verifies that all entries from a reference INI file are present in the source files and checks that the placeholders match properly.
 
 ```sh
 npx @dymerz/starcitizen-ini-utils validate <files...> [options]
+```
+
+#### Parameters:
+
+- `<files...>`: Paths to the INI files to validate
+
+#### Options:
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `--reference-type <type>` | Type of reference: "github", "local", or "url" | "github" |
+| `--github-branch <branch>` | GitHub branch to use | "main" |
+| `--github-repository <repo>` | GitHub repository path | "Dymerz/StarCitizen-Localization" |
+| `--github-file-path <path>` | Path to file within repository | "data/Localization/english/global.ini" |
+| `--local-path <path>` | Path to local reference file | (required when reference-type is "local") |
+| `--ci` | Run in CI mode (outputs errors differently) | false |
+
+#### Examples:
+
+```sh
+# Validate against main branch on GitHub (default)
+npx @dymerz/starcitizen-ini-utils validate ../../data/Localization/german_(germany)/global.ini
+
+# Validate against PTU branch
+npx @dymerz/starcitizen-ini-utils validate ../../data/Localization/german_(germany)/global.ini --github-branch ptu
+
+# Validate against local reference file
+npx @dymerz/starcitizen-ini-utils validate ../../data/Localization/german_(germany)/global.ini \
+  --reference-type local \
+  --local-path ../../data/Localization/english/global.ini
+
+### Command: `merge`
+
+Merges multiple INI files, taking values from files in order of priority, and saves the result to a new file.
+
+```sh
 npx @dymerz/starcitizen-ini-utils merge <referenceFilePath> <sourceFilePath> <replacementFilePath> <outputFilePath>
 ```
 
-### Using directly from GitHub repository
+#### Parameters:
 
-You can also use this tool directly with npx without cloning the repository:
+- `<referenceFilePath>`: Path to the reference INI file (provides the structure and fallback values)
+- `<sourceFilePath>`: Path to the source INI file (first priority for values)
+- `<replacementFilePath>`: Path to the replacement INI file (second priority for values)
+- `<outputFilePath>`: Path to save the merged INI file
 
-```sh
-npx github:Dymerz/StarCitizen-Localization/tools/ini-utils
-```
-
-Or with a specific command:
-
-```sh
-npx github:Dymerz/StarCitizen-Localization/tools/ini-utils validate <files...> [options]
-npx github:Dymerz/StarCitizen-Localization/tools/ini-utils merge <referenceFilePath> <sourceFilePath> <replacementFilePath> <outputFilePath>
-```
-
-### Installing as a dependency
-
-You can add this tool as a dependency to your project:
+#### Example:
 
 ```sh
-npm install @dymerz/starcitizen-ini-utils
+npx @dymerz/starcitizen-ini-utils merge \
+  ./english/global.ini \
+  ./french_old/global.ini \
+  ./french_updates/global.ini \
+  ./french_merged/global.ini
 ```
 
-### Validate INI Files
+## Technical Details
 
-To validate INI files, use the `validate` command. This command checks if all entries from a reference file are present in the source files and if the placeholders match.
+- Written in TypeScript with strong typing
+- Creates UTF-8 files with BOM (Byte Order Mark) for proper encoding
+- Handles special characters in INI files by properly escaping semicolons and hash symbols
+- Validates both percent placeholders (`%name`) and tilde placeholders (`~name(parameter)`)
+- Supports case-insensitive placeholder validation
 
-  ```sh
-  npx @dymerz/starcitizen-ini-utils validate <files...> [options]
-  ```
+## Contributing
 
-  - `<files...>`: Paths to the INI files to validate.
-  - `[options]`:
-    - `--reference-type <type>`: Type of reference: "github" or "local" (default: "github")
-    - `--github-branch <branch>`: GitHub branch to use (default: "main")
-    - `--github-repository <repository>`: GitHub repository path (default: "Dymerz/StarCitizen-Localization")
-    - `--github-file-path <path>`: Path to file within repository (default: "english/global.ini")
-    - `--local-path <path>`: Path to local reference file (required when reference-type is "local")
-    - `--ci`: Run in CI mode
+Contributions are welcome! Please feel free to submit a Pull Request.
 
-Examples:
+## License
 
-  ```sh
-  # Validate against main branch on GitHub (default)
-  npx @dymerz/starcitizen-ini-utils validate ../../data/Localization/french_(france)/global.ini
+[ISC License](LICENSE)
 
-  # Validate against PTU branch
-  npx @dymerz/starcitizen-ini-utils validate ../../data/Localization/french_(france)/global.ini --github-branch ptu
-
-  # Validate against local reference file
-  npx @dymerz/starcitizen-ini-utils validate ../../data/Localization/french_(france)/global.ini --reference-type local --local-path ../../data/Localization/english/global.ini
-
-  # Validate against custom URL
-  npx @dymerz/starcitizen-ini-utils validate ../../data/Localization/french_(france)/global.ini --reference-type url --url-path https://example.com/path/to/reference.ini
-  ```
-
-### Merge INI Files
-
-To merge INI files, use the `merge` command:
-
-  ```sh
-  npx @dymerz/starcitizen-ini-utils merge <referenceFilePath> <sourceFilePath> <replacementFilePath> <outputFilePath>
-  ```
-
-  - `<referenceFilePath>`: Path to the reference INI file.
-  - `<sourceFilePath>`: Path to the source INI file.
-  - `<replacementFilePath>`: Path to the replacement INI file.
-  - `<outputFilePath>`: Path to save the merged INI file.
+---
+Developed and maintained by [Dymerz](https://github.com/Dymerz)

--- a/tools/ini-utils/README.md
+++ b/tools/ini-utils/README.md
@@ -13,7 +13,7 @@
 
     ```sh
     git clone https://github.com/Dymerz/StarCitizen-Localization.git
-    cd <repository-directory>/tools/ini-utils
+    cd tools/ini-utils
     ```
 
 2. **Install dependencies:**
@@ -41,7 +41,7 @@ npx @dymerz/starcitizen-ini-utils
 Or with a specific command:
 
 ```sh
-npx @dymerz/starcitizen-ini-utils validate <source> [files...]
+npx @dymerz/starcitizen-ini-utils validate <files...> [options]
 npx @dymerz/starcitizen-ini-utils merge <referenceFilePath> <sourceFilePath> <replacementFilePath> <outputFilePath>
 ```
 
@@ -56,7 +56,7 @@ npx github:Dymerz/StarCitizen-Localization/tools/ini-utils
 Or with a specific command:
 
 ```sh
-npx github:Dymerz/StarCitizen-Localization/tools/ini-utils validate <source> [files...]
+npx github:Dymerz/StarCitizen-Localization/tools/ini-utils validate <files...> [options]
 npx github:Dymerz/StarCitizen-Localization/tools/ini-utils merge <referenceFilePath> <sourceFilePath> <replacementFilePath> <outputFilePath>
 ```
 
@@ -68,27 +68,37 @@ You can add this tool as a dependency to your project:
 npm install @dymerz/starcitizen-ini-utils
 ```
 
-Then configure your `.npmrc` file to use GitHub Packages:
-
-```
-@dymerz:registry=https://npm.pkg.github.com
-```
-
 ### Validate INI Files
 
 To validate INI files, use the `validate` command. This command checks if all entries from a reference file are present in the source files and if the placeholders match.
 
   ```sh
-  npx @dymerz/starcitizen-ini-utils validate <source> [files...]
+  npx @dymerz/starcitizen-ini-utils validate <files...> [options]
   ```
 
-  - `<source>`: Path to the english INI file.
-  - `[files...]`: Paths to the INI files to validate.
+  - `<files...>`: Paths to the INI files to validate.
+  - `[options]`:
+    - `--reference-type <type>`: Type of reference: "github" or "local" (default: "github")
+    - `--github-branch <branch>`: GitHub branch to use (default: "main")
+    - `--github-repository <repository>`: GitHub repository path (default: "Dymerz/StarCitizen-Localization")
+    - `--github-file-path <path>`: Path to file within repository (default: "english/global.ini")
+    - `--local-path <path>`: Path to local reference file (required when reference-type is "local")
+    - `--ci`: Run in CI mode
 
-Example:
+Examples:
 
   ```sh
-  npx @dymerz/starcitizen-ini-utils validate ../../data/Localization/english/global.ini ../../data/Localization/french_(france)/global.ini
+  # Validate against main branch on GitHub (default)
+  npx @dymerz/starcitizen-ini-utils validate ../../data/Localization/french_(france)/global.ini
+
+  # Validate against PTU branch
+  npx @dymerz/starcitizen-ini-utils validate ../../data/Localization/french_(france)/global.ini --github-branch ptu
+
+  # Validate against local reference file
+  npx @dymerz/starcitizen-ini-utils validate ../../data/Localization/french_(france)/global.ini --reference-type local --local-path ../../data/Localization/english/global.ini
+
+  # Validate against custom URL
+  npx @dymerz/starcitizen-ini-utils validate ../../data/Localization/french_(france)/global.ini --reference-type url --url-path https://example.com/path/to/reference.ini
   ```
 
 ### Merge INI Files

--- a/tools/ini-utils/package-lock.json
+++ b/tools/ini-utils/package-lock.json
@@ -1,17 +1,16 @@
 {
   "name": "@dymerz/starcitizen-ini-utils",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@dymerz/starcitizen-ini-utils",
-      "version": "1.0.0",
-      "hasInstallScript": true,
+      "version": "1.0.2",
       "license": "ISC",
       "dependencies": {
         "@types/ini": "^4.1.1",
-        "commander": "^13.1.0",
+        "commander": "^14.0.0",
         "ini": "^5.0.0",
         "nodemon": "^3.1.9",
         "ts-node": "^10.9.1",
@@ -1114,12 +1113,12 @@
       "license": "MIT"
     },
     "node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
+      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/commondir": {

--- a/tools/ini-utils/package.json
+++ b/tools/ini-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dymerz/starcitizen-ini-utils",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A utility tool for working with Star Citizen INI localization files",
   "main": "dist/src/index.js",
   "bin": {

--- a/tools/ini-utils/package.json
+++ b/tools/ini-utils/package.json
@@ -22,7 +22,7 @@
     "build": "tsc -p ."
   },
   "author": "Dymerz",
-  "license": "ISC",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/Dymerz/StarCitizen-Localization.git"

--- a/tools/ini-utils/package.json
+++ b/tools/ini-utils/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@types/ini": "^4.1.1",
-    "commander": "^13.1.0",
+    "commander": "^14.0.0",
     "ini": "^5.0.0",
     "nodemon": "^3.1.9",
     "ts-node": "^10.9.1",

--- a/tools/ini-utils/src/commands/validate.command.ts
+++ b/tools/ini-utils/src/commands/validate.command.ts
@@ -169,26 +169,26 @@ export class ValidateCommand
   /**
    * Fetches an Ini file from a GitHub repository.
    *
-   * @param repositoryUrl - The URL of the GitHub repository
+   * @param repository - The GitHub repository in the format 'owner/repo'
    * @param branch - The branch of the repository to fetch the file from
    * @param filePath - The path to the file within the repository
    * @returns A Promise resolving to an Ini object containing the file content
    */
-  private static async getFileFromRepository(repositoryUrl: string, branch: string, filePath: string): Promise<Ini>
+  private static async getFileFromRepository(repository: string, branch: string, filePath: string): Promise<Ini>
   {
-    console.log(`Loading reference file: ${filePath} from repository ${repositoryUrl} on branch ${branch}`);
-    const root = new URL(`https://raw.githubusercontent.com/${repositoryUrl}/${branch}/`);
-    const url = new URL(filePath, root);
+    console.log(`Loading reference file: ${filePath} from repository ${repository} on branch ${branch}`);
+    const repositoryBaseUrl = new URL(`https://raw.githubusercontent.com/${repository}/${branch}/`);
+    const resourceUrl = new URL(filePath, repositoryBaseUrl);
 
-    const response = await fetch(url.toString());
+    const response = await fetch(resourceUrl.toString());
     if (!response.ok)
     {
-      console.error(`Failed to fetch file from ${url.toString()}: ${response.statusText}`);
-      throw new Error(`Failed to fetch file from ${url.toString()}`);
+      console.error(`Failed to fetch file from ${resourceUrl.toString()}: ${response.statusText}`);
+      throw new Error(`Failed to fetch file from ${resourceUrl.toString()}`);
     }
     const content = await response.text();
     return {
-      path: url.toString(),
+      path: resourceUrl.toString(),
       content: IniHelper.parse(content)
     };
   }

--- a/tools/ini-utils/src/index.ts
+++ b/tools/ini-utils/src/index.ts
@@ -4,6 +4,25 @@ import { version } from '../package.json';
 import { MergeCommand } from './commands/merge.command';
 import { ValidateCommand } from './commands/validate.command';
 
+function parseSource(value: string, previous: string): string
+{
+  const validSources = ['remote', 'local'];
+
+  // If previous is defined, it should be one of the valid sources
+  if (previous && !validSources.includes(previous))
+    throw new Error(`Invalid source type: ${previous}. Expected "remote" or "local".`);
+
+  // If value is not provided, throw an error
+  if (!value)
+    throw new Error('Source type is required. Expected "remote" or "local".');
+
+  // If value is provided, it should be one of the valid sources
+  if (!validSources.includes(value))
+    throw new Error(`Invalid source type: ${value}. Expected "remote" or "local".`);
+  return value;
+}
+
+
 program
   .name('ini-utils')
   .description('A utility for working with Star Citizen INI localization files')
@@ -15,9 +34,14 @@ program
   .action(MergeCommand.run);
 
 program
-  .command('validate <source> [files...]')
-  .option('--ci', 'Run in CI mode')
-  .description('Check if all entries from reference file are present in other files')
+  .command('validate')
+  .argument('<files...>', 'Files to validate')
+  .description('Check if all entries in files are present and valid in the source file')
+  .option('--ci', 'Run in CI mode', false)
+  .option('--source <source>', 'Source type for reference file: "remote" or "local"', parseSource, 'remote')
+  .option('--remote-branch <branch>', 'Remote branch to use as reference (main, ptu, etc.)', 'main')
+  .option('--remote-repository <repository>', 'Remote repository path', 'Dymerz/StarCitizen-Localization')
+  .option('--local-reference <path>', 'Path to local reference file when using local source')
   .action(ValidateCommand.run);
 
 program.parse();

--- a/tools/ini-utils/src/index.ts
+++ b/tools/ini-utils/src/index.ts
@@ -37,7 +37,7 @@ program
   .command('validate')
   .argument('<files...>', 'Files to validate')
   .description('Check if all entries in files are present and valid in the source file')
-  .option('--reference-type <type>', 'Type of reference: "github" or "local"', 'github')
+  .option('--reference-type <type>', 'Type of reference: "github" or "local"', parseSource, 'github')
   .option('--github-branch <branch>', 'GitHub branch to use as reference (main, ptu, etc.)', 'main')
   .option('--github-repository <repository>', 'GitHub repository path', 'Dymerz/StarCitizen-Localization')
   .option('--github-file-path <path>', 'Path to file within repository', 'data/Localization/english/global.ini')

--- a/tools/ini-utils/src/index.ts
+++ b/tools/ini-utils/src/index.ts
@@ -37,12 +37,12 @@ program
   .command('validate')
   .argument('<files...>', 'Files to validate')
   .description('Check if all entries in files are present and valid in the source file')
-  .option('--ci', 'Run in CI mode', false)
   .option('--reference-type <type>', 'Type of reference: "github" or "local"', 'github')
   .option('--github-branch <branch>', 'GitHub branch to use as reference (main, ptu, etc.)', 'main')
   .option('--github-repository <repository>', 'GitHub repository path', 'Dymerz/StarCitizen-Localization')
   .option('--github-file-path <path>', 'Path to file within repository', 'data/Localization/english/global.ini')
   .option('--local-path <path>', 'Path to local reference file')
+  .option('--ci', 'Run in CI mode', false)
   .action(ValidateCommand.run);
 
 program.parse();

--- a/tools/ini-utils/src/index.ts
+++ b/tools/ini-utils/src/index.ts
@@ -6,19 +6,19 @@ import { ValidateCommand } from './commands/validate.command';
 
 function parseSource(value: string, previous: string): string
 {
-  const validSources = ['remote', 'local'];
+  const validSources = ['github', 'local'];
 
   // If previous is defined, it should be one of the valid sources
   if (previous && !validSources.includes(previous))
-    throw new Error(`Invalid source type: ${previous}. Expected "remote" or "local".`);
+    throw new Error(`Invalid source type: ${previous}. Expected "github" or "local".`);
 
   // If value is not provided, throw an error
   if (!value)
-    throw new Error('Source type is required. Expected "remote" or "local".');
+    throw new Error('Source type is required. Expected "github" or "local".');
 
   // If value is provided, it should be one of the valid sources
   if (!validSources.includes(value))
-    throw new Error(`Invalid source type: ${value}. Expected "remote" or "local".`);
+    throw new Error(`Invalid source type: ${value}. Expected "github" or "local".`);
   return value;
 }
 
@@ -38,10 +38,11 @@ program
   .argument('<files...>', 'Files to validate')
   .description('Check if all entries in files are present and valid in the source file')
   .option('--ci', 'Run in CI mode', false)
-  .option('--source <source>', 'Source type for reference file: "remote" or "local"', parseSource, 'remote')
-  .option('--remote-branch <branch>', 'Remote branch to use as reference (main, ptu, etc.)', 'main')
-  .option('--remote-repository <repository>', 'Remote repository path', 'Dymerz/StarCitizen-Localization')
-  .option('--local-reference <path>', 'Path to local reference file when using local source')
+  .option('--reference-type <type>', 'Type of reference: "github" or "local"', 'github')
+  .option('--github-branch <branch>', 'GitHub branch to use as reference (main, ptu, etc.)', 'main')
+  .option('--github-repository <repository>', 'GitHub repository path', 'Dymerz/StarCitizen-Localization')
+  .option('--github-file-path <path>', 'Path to file within repository', 'data/Localization/english/global.ini')
+  .option('--local-path <path>', 'Path to local reference file')
   .action(ValidateCommand.run);
 
 program.parse();

--- a/tools/ini-utils/src/shared/helpers/ini.helper.ts
+++ b/tools/ini-utils/src/shared/helpers/ini.helper.ts
@@ -1,10 +1,6 @@
-// External modules
-import * as fs  from 'fs';
+import * as fs from 'fs';
 import * as ini from 'ini';
-
-// Interfaces
-import { Ini }  from '../types/ini.type';
-
+import { Ini } from '../types/ini.type';
 
 export class IniHelper
 {
@@ -19,6 +15,19 @@ export class IniHelper
   }
 
   /**
+   * Parses the provided INI content into a record where keys are strings and values are strings or undefined.
+   * The method first escapes the values in the content using {@link IniHelper.escapeValues} before parsing.
+   *
+   * @param content - The INI content to parse as a string
+   * @returns A record with string keys and string or undefined values representing the parsed INI content
+   */
+  public static parse(content: string): Record<string, string | undefined>
+  {
+    const contentEscaped = IniHelper.escapeValues(content);
+    return ini.parse(contentEscaped);
+  }
+
+  /**
    * Load an INI file and return its content as an object
    * @param filePath
    * @returns
@@ -26,11 +35,10 @@ export class IniHelper
   public static loadFile(filePath: string): Ini
   {
     const fileContent = IniHelper.readFileSync(filePath);
-    const fileContentEscaped = IniHelper.escapeValues(fileContent);
 
-    const parsed = ini.parse(fileContentEscaped);
+    const parsed = IniHelper.parse(fileContent);
     return {
-      path   : filePath,
+      path: filePath,
       content: parsed
     };
   }
@@ -42,7 +50,7 @@ export class IniHelper
    */
   public static writeFile(file: Ini): void
   {
-    IniHelper.writeFileSync(file.path, '\ufeff'+ini.stringify(file.content), { encoding: 'utf-8',  });
+    IniHelper.writeFileSync(file.path, '\ufeff' + ini.stringify(file.content), { encoding: 'utf-8', });
   }
 
   /**

--- a/tools/ini-utils/test/commands/validate-run.spec.ts
+++ b/tools/ini-utils/test/commands/validate-run.spec.ts
@@ -1,10 +1,7 @@
-// External modules
+import assert from 'assert';
+import sinon from 'sinon';
 import { ValidateCommand } from '../../src/commands/validate.command';
-import assert              from 'assert';
-import sinon               from 'sinon'
-
-// Helpers
-import { IniHelper }       from '../../src/shared/helpers/ini.helper';
+import { IniHelper } from '../../src/shared/helpers/ini.helper';
 
 
 describe('ValidateCommand.run', () =>
@@ -15,7 +12,7 @@ describe('ValidateCommand.run', () =>
   // Disable console.log
   beforeEach(() =>
   {
-    consoleLogStub = sinon.stub(console, 'log').callsFake(() => {});
+    consoleLogStub = sinon.stub(console, 'log').callsFake(() => { });
     loadFileStub = sinon.stub(IniHelper, 'loadFile');
   });
 
@@ -25,19 +22,16 @@ describe('ValidateCommand.run', () =>
     loadFileStub.restore();
   });
 
-  it('should log "No files to validate" when no files are provided', async () =>
-  {
-    await ValidateCommand.run('reference.ini', [], { ci: false });
-
-    assert.ok(consoleLogStub.calledWith('No files to validate'), 'Expected log message not found');
-  });
-
   it('should validate files successfully', async () =>
   {
     loadFileStub.onFirstCall().returns({ content: { key1: 'value1' } });
     loadFileStub.onSecondCall().returns({ content: { key1: 'value1' } });
 
-    await ValidateCommand.run('reference.ini', ['file1.ini'], { ci: false });
+    await ValidateCommand.run(['file1.ini'], {
+      ci: false,
+      referenceType: 'local',
+      localPath: 'reference.ini'
+    });
     assert.ok(consoleLogStub.calledWith('File "file1.ini" is valid ✅'), 'Expected valid file log message not found');
   });
 
@@ -46,7 +40,11 @@ describe('ValidateCommand.run', () =>
     loadFileStub.onFirstCall().returns({ content: { key1: 'valid placeholder ~name(parameter)' } });
     loadFileStub.onSecondCall().returns({ content: { key1: 'missing placeholder' } });
 
-    await ValidateCommand.run('reference.ini', ['file1.ini'], { ci: false });
+    await ValidateCommand.run(['file1.ini'], {
+      ci: false,
+      referenceType: 'local',
+      localPath: 'reference.ini'
+    });
     assert.ok(consoleLogStub.calledWith('File "file1.ini" is invalid 🔥'), 'Expected invalid file log message not found');
   });
 
@@ -56,14 +54,81 @@ describe('ValidateCommand.run', () =>
     loadFileStub.onSecondCall().returns({ content: { key1: 'missing placeholder' } });
 
     const processExitStub = sinon.stub(process, 'exit');
-    try
-    {
-      await ValidateCommand.run('reference.ini', ['file1.ini'], { ci: true });
-    } catch (e)
-    {
-      // process.exit will throw an error in the test environment
-    }
+
+    await ValidateCommand.run(['file1.ini'], {
+      ci: true,
+      referenceType: 'local',
+      localPath: 'reference.ini'
+    });
+
     assert.ok(processExitStub.calledWith(1), 'Expected process.exit with code 1');
     processExitStub.restore();
+  });
+
+  it('should handle invalid reference type', async () =>
+  {
+    assert.rejects(async () =>
+    {
+      await ValidateCommand.run(['file1.ini'], {
+        ci: false,
+        referenceType: 'invalid' as any
+      });
+    }, Error);
+  });
+
+  it('should handle missing ci option', async () =>
+  {
+    assert.rejects(async () =>
+    {
+      await ValidateCommand.run(['file1.ini'], {
+        referenceType: 'local',
+        localPath: 'reference.ini'
+      });
+    }, Error);
+  });
+
+  it('should handle missing required options for local reference', async () =>
+  {
+    assert.rejects(async () =>
+    {
+      await ValidateCommand.run(['file1.ini'], {
+        ci: false,
+        referenceType: 'local'
+        // localPath missing
+      });
+    }, Error);
+  });
+
+  it('should handle missing required options for github reference', async () =>
+  {
+    assert.rejects(async () =>
+    {
+      await ValidateCommand.run(['file1.ini'], {
+        ci: false,
+        referenceType: 'github'
+        // Missing 'githubRepository' options
+      });
+    }, Error);
+
+    assert.rejects(async () =>
+    {
+      await ValidateCommand.run(['file1.ini'], {
+        ci: false,
+        referenceType: 'github',
+        githubRepository: 'owner/repo'
+        // Missing 'githubBranch' options
+      });
+    }, Error);
+
+    assert.rejects(async () =>
+    {
+      await ValidateCommand.run(['file1.ini'], {
+        ci: false,
+        referenceType: 'github',
+        githubRepository: 'owner/repo',
+        githubBranch: 'main'
+        // Missing 'githubFilePath' options
+      });
+    }, Error);
   });
 });


### PR DESCRIPTION
Introduces several significant updates across licensing, CI configuration, documentation, and the `validate` command implementation for the `StarCitizen INI Utils` tool. Below is a summary of the most important changes grouped by theme:

### Licensing and CI Configuration
* **License Change**: The project license was updated from CC0 1.0 Universal to the MIT License, reflecting a shift to a more permissive and widely-used licensing model. (`LICENSE`, `tools/ini-utils/package.json`) [[1]](diffhunk://#diff-c693279643b8cd5d248172d9c22cb7cf4ed163a3c98c8a3f69c2717edd3eacb7L1-R21) [[2]](diffhunk://#diff-9b401a6af5afa049258267891f273711fdc362093ccfc42e65b2992c813d5949L25-R32)
* **CI Workflow Permissions**: Added `pull-requests: write` permission to the GitHub Actions workflow configuration to support pull request-related operations. (`.github/workflows/ini-utils-ci.yaml`)

### Documentation Enhancements
* **README Overhaul**: The `README.md` file was significantly expanded to include detailed sections on usage, installation options, key features, technical details, and contributing guidelines. It also added badges for build status, npm version, Node.js version, and license. (`tools/ini-utils/README.md`) [[1]](diffhunk://#diff-ed9fb118a314394cb77f7fdac15e13d43cfcd3270c2e3d19921f5e0f641278d9L1-R45) [[2]](diffhunk://#diff-ed9fb118a314394cb77f7fdac15e13d43cfcd3270c2e3d19921f5e0f641278d9R60-R147)

### `validate` Command Enhancements
* **Options Refactor**: Introduced new types (`ValidateCommandOptionsLocal`, `ValidateCommandOptionsGithub`, and `ValidateCommandOptions`) to handle `validate` command options for local and GitHub-based reference files. (`tools/ini-utils/src/commands/validate.command.ts`)
* **New Methods**: Added methods to fetch reference files either from a local path or a GitHub repository, enhancing the flexibility of the `validate` command. (`tools/ini-utils/src/commands/validate.command.ts`)

### Dependency Updates
* **Commander Upgrade**: Updated the `commander` package from version 13.1.0 to 14.0.0, requiring Node.js version 20 or higher. (`tools/ini-utils/package-lock.json`, `tools/ini-utils/package.json`) [[1]](diffhunk://#diff-27d46e8c45101dfd45df8023eb4771a6129bd1490291dc709d675af2a66b4a13L3-R13) [[2]](diffhunk://#diff-27d46e8c45101dfd45df8023eb4771a6129bd1490291dc709d675af2a66b4a13L1117-R1121) [[3]](diffhunk://#diff-9b401a6af5afa049258267891f273711fdc362093ccfc42e65b2992c813d5949L25-R32)

### Versioning
* **Package Version Bump**: Incremented the package version from `1.0.2` to `1.0.3` to reflect the new changes and improvements. (`tools/ini-utils/package.json`)