### PR TITLE
fix: update CI workflow to remove unnecessary paths and add draft PR

### DIFF
--- a/.github/workflows/ini-utils-ci.yaml
+++ b/.github/workflows/ini-utils-ci.yaml
@@ -5,12 +5,10 @@ on:
   pull_request:
     paths:
       - 'tools/ini-utils/**'
-      - '.github/workflows/ini-utils-ci.yaml'
   push:
     branches: [main]
     paths:
       - 'tools/ini-utils/**'
-      - '.github/workflows/ini-utils-ci.yaml'
 
 jobs:
   build:
@@ -134,6 +132,8 @@ jobs:
         commit-message: "chore: bump ini-utils version to ${{ needs.build.outputs.new_version }}"
         branch: automated-version-bump-ini-utils
         delete-branch: true
+        draft: always-true
+        assignees: Dymerz
         base: main
         title: "chore: bump ini-utils version to ${{ needs.build.outputs.new_version }}"
         body: |


### PR DESCRIPTION
Updates the GitHub Actions workflow configuration for `ini-utils`. The changes primarily adjust the workflow triggers and enhance the automated pull request creation process.

### Workflow trigger updates:
* Removed `.github/workflows/ini-utils-ci.yaml` from the list of paths that trigger the workflow on `pull_request` and `push` events. This prevents unnecessary workflow runs when changes are made to the workflow file itself.

### Automated pull request enhancements:
* Added `draft: always-true` and assigned the pull request to `Dymerz` in the `jobs` section to improve the automation of version bump pull requests.