### PR TITLE
feat: add version existence check before publishing to npm

### DIFF
--- a/.github/workflows/ini-utils-ci.yaml
+++ b/.github/workflows/ini-utils-ci.yaml
@@ -66,7 +66,7 @@ jobs:
       run: |
         CURRENT_VERSION=$(node -p "require('./package.json').version")
         echo "Current version: $CURRENT_VERSION"
-        echo "new_version=v$CURRENT_VERSION" >> $GITHUB_OUTPUT
+        echo "new_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
 
     - name: Upload package.json
       if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -119,7 +119,32 @@ jobs:
         node-version: 22
         registry-url: 'https://registry.npmjs.org'
 
+    - name: Check if version exists on npm
+      id: version_check
+      run: |
+        PACKAGE_NAME="@dymerz/starcitizen-ini-utils"
+        CURRENT_VERSION="${{ needs.build.outputs.new_version }}"
+
+        echo "Checking if version $CURRENT_VERSION already exists on npm for package $PACKAGE_NAME"
+
+        PUBLISHED_VERSION=$(npm show $PACKAGE_NAME version 2>/dev/null || echo "not_found")
+        echo "Published version on npm: $PUBLISHED_VERSION"
+
+        if [ "$PUBLISHED_VERSION" == "$CURRENT_VERSION" ]; then
+          echo "Version $CURRENT_VERSION already exists on npm, skipping publish"
+          echo "version_exists=true" >> $GITHUB_OUTPUT
+        else
+          echo "Version $CURRENT_VERSION does not exist on npm, will publish"
+          echo "version_exists=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Skip message
+      if: steps.version_check.outputs.version_exists == 'true'
+      run: |
+        echo "::notice ::Version ${{ needs.build.outputs.new_version }} already exists on npm, skipping publish and PR creation"
+
     - name: Publish to npmjs
+      if: steps.version_check.outputs.version_exists != 'true'
       run: |
         echo "Publishing version ${{ needs.build.outputs.new_version }} to npmjs"
         npm publish --provenance --access public *.tgz
@@ -127,6 +152,7 @@ jobs:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
     - name: Create Pull Request for version bump
+      if: steps.version_check.outputs.version_exists != 'true'
       uses: peter-evans/create-pull-request@v7
       with:
         commit-message: "chore: bump ini-utils version to ${{ needs.build.outputs.new_version }}"


### PR DESCRIPTION
Updates the `.github/workflows/ini-utils-ci.yaml` file to improve version handling during the CI/CD workflow. The changes ensure that the workflow checks if a version already exists on npm before publishing or creating a pull request, thereby avoiding redundant operations.

### Improvements to CI/CD Workflow:

* **Fixed version output format**: Updated the `new_version` output to exclude the `v` prefix, aligning it with npm's expected version format. (`[.github/workflows/ini-utils-ci.yamlL69-R69](diffhunk://#diff-f7d4113aba6e595fb01465655a320822f00203aebd51e4a1fa89f1df359d6ed7L69-R69)`)

* **Added npm version existence check**: Introduced a step to check if the current version of the package already exists on npm. If the version exists, the workflow skips the publish and pull request creation steps. (`[.github/workflows/ini-utils-ci.yamlR122-R155](diffhunk://#diff-f7d4113aba6e595fb01465655a320822f00203aebd51e4a1fa89f1df359d6ed7R122-R155)`)

* **Conditional publishing and PR creation**: Added conditions to skip the publish and pull request creation steps if the version already exists on npm, preventing unnecessary actions. (`[.github/workflows/ini-utils-ci.yamlR122-R155](diffhunk://#diff-f7d4113aba6e595fb01465655a320822f00203aebd51e4a1fa89f1df359d6ed7R122-R155)`)