### PR TITLE
fix: remove unnecessary download step for package.json in CI workflow

### DIFF
--- a/.github/workflows/ini-utils-ci.yaml
+++ b/.github/workflows/ini-utils-ci.yaml
@@ -104,13 +104,6 @@ jobs:
       run: |
         echo "::notice ::Version ${{ needs.build.outputs.new_version }} already exists on npm, skipping publish and PR creation"
 
-    - name: Download updated package.json
-      if: steps.version_check.outputs.version_exists != 'true'
-      uses: actions/download-artifact@v4
-      with:
-        name: package-json
-        path: tools/ini-utils/
-
     - name: Download package artifact
       if: steps.version_check.outputs.version_exists != 'true'
       uses: actions/download-artifact@v4


### PR DESCRIPTION
Minor update to the CI workflow in `.github/workflows/ini-utils-ci.yaml`. It removes an unnecessary step for downloading an updated `package.json` file, likely as part of a cleanup or optimization effort.

* **CI workflow improvement**:
  - Removed the step for downloading an updated `package.json` file when the version does not already exist, streamlining the workflow. (`.github/workflows/ini-utils-ci.yaml`, [.github/workflows/ini-utils-ci.yamlL107-L113](diffhunk://#diff-f7d4113aba6e595fb01465655a320822f00203aebd51e4a1fa89f1df359d6ed7L107-L113))