### PR TITLE
feat: add --fail-on-error flag to validation command in workflow

### DIFF
--- a/.github/workflows/validate-global-ini.yaml
+++ b/.github/workflows/validate-global-ini.yaml
@@ -98,4 +98,4 @@ jobs:
         node-version: 22
 
     - name: Validate key/value pairs
-      run: npx @dymerz/starcitizen-ini-utils validate --ci --reference-type local --local-path "$GITHUB_WORKSPACE/data/Localization/english/global.ini" ${{ needs.prepare.outputs.changed-files }}
+      run: npx @dymerz/starcitizen-ini-utils validate --ci --fail-on-error --reference-type local --local-path "$GITHUB_WORKSPACE/data/Localization/english/global.ini" ${{ needs.prepare.outputs.changed-files }}


### PR DESCRIPTION
Introduces a minor update to the `.github/workflows/validate-global-ini.yaml` file to enhance error handling during the validation process.

* **Improved validation error handling**:
  - Updated the `Validate key/value pairs` step to include the `--fail-on-error` flag in the `npx @dymerz/starcitizen-ini-utils validate` command. This ensures the workflow fails if any validation errors are encountered.