### PR TITLE
feat: add analytics section with Repobeats image to multiple README f…

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,5 +150,9 @@ To update the localization files, please follow the [Installation Guide](#instal
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 ---
+## Analytics
+![Alt](https://repobeats.axiom.co/api/embed/771a52550a3333c3934d1fb5a03fffa14119471a.svg "Repobeats analytics image")
+
+---
 ## Disclaimer
 This is an unofficial Star Citizen fansite, not affiliated with the Cloud Imperium group of companies. All content on this site not authored by its host or users are property of their respective owners. Star Citizen®, Roberts Space Industries® and Cloud Imperium® are registered trademarks of Cloud Imperium Rights LLC

--- a/README_de.md
+++ b/README_de.md
@@ -133,5 +133,9 @@ Um die Lokalisierungsdateien zu aktualisieren, folgen Sie bitte erneut der [Inst
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 ---
+## Statistik
+![Alt](https://repobeats.axiom.co/api/embed/771a52550a3333c3934d1fb5a03fffa14119471a.svg "Repobeats analytics image")
+
+---
 ## Haftungsausschluss
 Dies ist eine inoffizielle Star Citizen Fanseite und steht in keiner Verbindung zur Cloud Imperium Unternehmensgruppe. Alle Inhalte auf dieser Seite, die nicht vom Host oder den Benutzern erstellt wurden, sind Eigentum ihrer jeweiligen Besitzer. Star Citizen®, Roberts Space Industries® und Cloud Imperium® sind eingetragene Marken von Cloud Imperium Rights LLC.

--- a/README_es.md
+++ b/README_es.md
@@ -162,7 +162,9 @@ Para actualizar los archivos, sigue nuevamente la [Guía de Instalación](#insta
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 ---
+## Analítica
+![Alt](https://repobeats.axiom.co/api/embed/771a52550a3333c3934d1fb5a03fffa14119471a.svg "Repobeats analytics image")
 
+---
 ## Descargo de Responsabilidad
-
 Este es un sitio de fans no oficial de Star Citizen, sin afiliación con el grupo de compañías Cloud Imperium. Todo el contenido no creado por los administradores o usuarios es propiedad de sus respectivos dueños. Star Citizen®, Roberts Space Industries® y Cloud Imperium® son marcas registradas de Cloud Imperium Rights LLC.

--- a/README_fr.md
+++ b/README_fr.md
@@ -135,5 +135,9 @@ Pour mettre à jour les fichiers de localisation, veuillez suivre à nouveau le 
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 ---
+## Analytique
+![Alt](https://repobeats.axiom.co/api/embed/771a52550a3333c3934d1fb5a03fffa14119471a.svg "Repobeats analytics image")
+
+---
 ## Avis de non-responsabilité
 Il s'agit d'un site de fans non officiel de Star Citizen, sans affiliation avec le groupe de sociétés Cloud Imperium. Tout le contenu de ce site qui n'a pas été rédigé par son hôte ou ses utilisateurs est la propriété de leurs propriétaires respectifs. Star Citizen®, Roberts Space Industries® et Cloud Imperium® sont des marques déposées de Cloud Imperium Rights LLC.

--- a/README_it.md
+++ b/README_it.md
@@ -135,5 +135,9 @@ Per aggiornare i file di localizzazione, segui nuovamente la guida [Installazion
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 ---
+## Analisi
+![Alt](https://repobeats.axiom.co/api/embed/771a52550a3333c3934d1fb5a03fffa14119471a.svg "Repobeats analytics image")
+
+---
 ## Disclaimer
 This is an unofficial Star Citizen fansite, not affiliated with the Cloud Imperium group of companies. All content on this site not authored by its host or users are property of their respective owners. Star Citizen®, Roberts Space Industries® and Cloud Imperium® are registered trademarks of Cloud Imperium Rights LLC

--- a/README_ptbr.md
+++ b/README_ptbr.md
@@ -134,5 +134,9 @@ Para atualizar os arquivos de localização, siga novamente o [Guia de Instalaç
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 ---
+## Estatísticas
+![Alt](https://repobeats.axiom.co/api/embed/771a52550a3333c3934d1fb5a03fffa14119471a.svg "Repobeats analytics image")
+
+---
 ## Disclaimer
 Este é um site não oficial de fãs de Star Citizen, não afiliado ao grupo de empresas Cloud Imperium. Todo o conteúdo deste site que não seja de autoria de seu anfitrião ou de seus usuários é de propriedade de seus respectivos donos. Star Citizen®, Roberts Space Industries® e Cloud Imperium® são marcas registradas da Cloud Imperium Rights LLC


### PR DESCRIPTION
Introduces an analytics section to multiple localized `README` files, displaying a Repobeats analytics image. The change ensures consistency across all language versions of the documentation.

### Additions to localized `README` files:

* Added a "## Analytics" section with a Repobeats analytics image to the English `README.md` file.
* Added a "## Statistik" section with a Repobeats analytics image to the German `README_de.md` file.
* Added a "## Analítica" section with a Repobeats analytics image to the Spanish `README_es.md` file.
* Added a "## Analytique" section with a Repobeats analytics image to the French `README_fr.md` file.
* Added a "## Analisi" section with a Repobeats analytics image to the Italian `README_it.md` file.
* Added a "## Estatísticas" section with a Repobeats analytics image to the Brazilian Portuguese `README_ptbr.md` file.