### PR TITLE
Update French badge color to yellow

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 | Language                 | Supported | Source |
 |--------------------------|-----------|--------|
 | English                  | ![Static Badge](https://img.shields.io/badge/4.7.0-LIVE-brightgreen) | Imported from game files |
-| French - France          | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-orange) | Generated from [circuspes.fr](https://traduction.circuspes.fr) |
+| French - France          | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Generated from [circuspes.fr](https://traduction.circuspes.fr) |
 | German - Germany         | ![Static Badge](https://img.shields.io/badge/4.2.0-LIVE-orange) | Here |
 | Portuguese - Brazil      | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Here |
 | Italian - Italy          | ![Static Badge](https://img.shields.io/badge/3.24.1-LIVE-yellow) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) and [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |

--- a/README_de.md
+++ b/README_de.md
@@ -30,7 +30,7 @@
 | Sprache                 | Unterstützt | Quelle |
 |--------------------------|-------------|--------|
 | Englisch                | ![Static Badge](https://img.shields.io/badge/4.7.0-LIVE-brightgreen) | Aus Spieldateien importiert |
-| Französisch - Frankreich | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-orange) | Generiert von [circuspes.fr](https://traduction.circuspes.fr) |
+| Französisch - Frankreich | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Generiert von [circuspes.fr](https://traduction.circuspes.fr) |
 | Deutsch - Deutschland   | ![Static Badge](https://img.shields.io/badge/4.2.0-LIVE-orange) | Hier |
 | Portugiesisch - Brasilien| ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Hier |
 | Italienisch - Italien   | ![Static Badge](https://img.shields.io/badge/3.24.1-LIVE-yellow) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) und [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |

--- a/README_es.md
+++ b/README_es.md
@@ -34,7 +34,7 @@
 | Idioma                  | Soporte                                                            | Fuente                                                                                                                              |
 | ----------------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
 | Inglés                  | ![Static Badge](https://img.shields.io/badge/4.7.0-LIVE-brightgreen)   | Importado de archivos del juego                                                                                                     |
-| Francés - Francia       | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-orange) | Generado desde [circuspes.fr](https://traduction.circuspes.fr) |
+| Francés - Francia       | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Generado desde [circuspes.fr](https://traduction.circuspes.fr) |
 | Alemán (Alemania)       | ![Static Badge](https://img.shields.io/badge/4.2.0-LIVE-orange)   | Aquí                                                                                                                                |
 | Portugués (Brasil)      | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow)   | Aquí                                                                                                                                |
 | Italiano (Italia)       | ![Static Badge](https://img.shields.io/badge/3.24.1-LIVE-yellow)    | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) y [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |

--- a/README_fr.md
+++ b/README_fr.md
@@ -31,7 +31,7 @@
 | Langue                  | Pris en charge | Source |
 |--------------------------|----------------|--------|
 | Anglais                 | ![Static Badge](https://img.shields.io/badge/4.7.0-LIVE-brightgreen) | Importé des fichiers du jeu |
-| Français - France       | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-orange) | Généré depuis [circuspes.fr](https://traduction.circuspes.fr) |
+| Français - France       | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Généré depuis [circuspes.fr](https://traduction.circuspes.fr) |
 | Allemand - Allemagne    | ![Static Badge](https://img.shields.io/badge/4.2.0-LIVE-orange) | Ici |
 | Portugais - Brésil      | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Ici |
 | Italien - Italie        | ![Static Badge](https://img.shields.io/badge/3.24.1-LIVE-yellow) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) et [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |

--- a/README_it.md
+++ b/README_it.md
@@ -31,7 +31,7 @@
 | Lingua                  | Supportato | Fonte |
 |--------------------------|------------|-------|
 | Inglese                 | ![Static Badge](https://img.shields.io/badge/4.7.0-LIVE-brightgreen) | Importato dai file di gioco |
-| Francese - Francia      | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-orange) | Generato da [circuspes.fr](https://traduction.circuspes.fr) |
+| Francese - Francia      | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Generato da [circuspes.fr](https://traduction.circuspes.fr) |
 | Tedesco - Germania      | ![Static Badge](https://img.shields.io/badge/4.2.0-LIVE-orange) | Qui |
 | Portoghese - Brasile    | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Qui |
 | Italiano - Italia       | ![Static Badge](https://img.shields.io/badge/3.24.1-LIVE-yellow) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) e [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |

--- a/README_ptbr.md
+++ b/README_ptbr.md
@@ -30,7 +30,7 @@
 | Idioma                  | Suportado | Fonte |
 |--------------------------|-----------|-------|
 | Inglês                  | ![Static Badge](https://img.shields.io/badge/4.7.0-LIVE-brightgreen) | Importado dos arquivos do jogo |
-| Francês - França        | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-orange) | Gerado de [circuspes.fr](https://traduction.circuspes.fr) |
+| Francês - França        | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Gerado de [circuspes.fr](https://traduction.circuspes.fr) |
 | Alemão - Alemanha       | ![Static Badge](https://img.shields.io/badge/4.2.0-LIVE-orange) | Aqui |
 | Português - Brasil      | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Aqui |
 | Italiano - Itália       | ![Static Badge](https://img.shields.io/badge/3.24.1-LIVE-yellow) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) e [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |

--- a/README_tr.md
+++ b/README_tr.md
@@ -30,7 +30,7 @@
 | Dil                      | Durum | Kaynak |
 |--------------------------|-------|--------|
 | Ingilizce                | ![Static Badge](https://img.shields.io/badge/4.7.0-LIVE-brightgreen) | Oyun dosyalarindan içe aktarildi |
-| Fransizca - Fransa       | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-orange) | [circuspes.fr](https://traduction.circuspes.fr) üzerinden olusturuldu |
+| Fransizca - Fransa       | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | [circuspes.fr](https://traduction.circuspes.fr) üzerinden olusturuldu |
 | Almanca - Almanya        | ![Static Badge](https://img.shields.io/badge/4.2.0-LIVE-orange) | Burada |
 | Portekizce - Brezilya    | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Burada |
 | Italyanca - Italya       | ![Static Badge](https://img.shields.io/badge/3.24.1-LIVE-yellow) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) ve [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |


### PR DESCRIPTION
Change the French - France status badge color from orange to yellow across README files (README.md, README_de.md, README_es.md, README_fr.md, README_it.md, README_ptbr.md, README_tr.md). No content or version changes — purely a visual/status badge update to keep presentation consistent.