### PR TITLE
Update Italian localization badge for correct version status

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@
 | French - France          | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Generated from [circuspes.fr](https://traduction.circuspes.fr) |
 | German - Germany         | ![Static Badge](https://img.shields.io/badge/4.2.0-LIVE-orange) | Here |
 | Portuguese - Brazil      | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Here |
-| Italian - Italy          | ![Static Badge](https://img.shields.io/badge/4.7.2-LIVE-brightgreen) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) and [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
+| Italian - Italy          | ![Static Badge](https://img.shields.io/badge/4.7.2-LIVE-yellow) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) and [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
 | Spanish - Spain          | ![Static Badge](https://img.shields.io/badge/3.23.1a-LIVE-orange) | Here |
 | Turkish - Turkey         | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Here |
 | Spanish - Latin America  | ![Static Badge](https://img.shields.io/badge/x.xx.x-LIVE-darkred) | Awaiting contribution |


### PR DESCRIPTION
This pull request makes a minor update to the `README.md` file, changing the badge color for the Italian (Italy) translation from bright green to yellow to reflect a status change.