### PR TITLE
Update README files: TOC, sections, badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# StarCitizen-Localization 🌎
+# StarCitizen-Localization 🌎<!-- omit in toc -->
 
 [![Discord](https://img.shields.io/discord/1185135396112322620?logo=discord&label=discord)](https://discord.gg/Gbvz9fTmZU)
 ![GitHub all releases](https://img.shields.io/github/downloads/Dymerz/StarCitizen-Localization/total)
@@ -20,9 +20,15 @@
 **Table of Contents:**
 - [Supported Languages](#supported-languages)
 - [Installation Guide](#installation-guide)
-- [Updating the Localization Files](#contributing)
+  - [Easiest Installation Method (PowerShell)](#easiest-installation-method-powershell)
+  - [Automatic Installation (Alternative)](#automatic-installation-alternative)
+  - [Manual Installation](#manual-installation)
+    - [Example `user.cfg` File:](#example-usercfg-file)
+- [Updating the Localization Files](#updating-the-localization-files)
 - [Contributing](#contributing)
-- [Disclaimer](#Disclaimer)
+- [Contributors](#contributors)
+- [Analytics](#analytics)
+- [Disclaimer](#disclaimer)
 
 ---
 ## Supported Languages
@@ -33,7 +39,7 @@
 | French - France          | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Generated from [circuspes.fr](https://traduction.circuspes.fr) |
 | German - Germany         | ![Static Badge](https://img.shields.io/badge/4.2.0-LIVE-orange) | Here |
 | Portuguese - Brazil      | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Here |
-| Italian - Italy          | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-green) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) and [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
+| Italian - Italy          | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) and [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
 | Spanish - Spain          | ![Static Badge](https://img.shields.io/badge/3.23.1a-LIVE-orange) | Here |
 | Turkish - Turkey         | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Here |
 | Spanish - Latin America  | ![Static Badge](https://img.shields.io/badge/x.xx.x-LIVE-darkred) | Awaiting contribution |

--- a/README_de.md
+++ b/README_de.md
@@ -1,4 +1,4 @@
-# StarCitizen-Übersetzung 🌎
+# StarCitizen-Übersetzung 🌎<!-- omit in toc -->
 
 [![Discord](https://img.shields.io/discord/1185135396112322620?logo=discord&label=discord)](https://discord.gg/Gbvz9fTmZU)
 ![GitHub all releases](https://img.shields.io/github/downloads/Dymerz/StarCitizen-Localization/total)
@@ -20,8 +20,14 @@
 **Inhaltsverzeichnis:**
 - [Unterstützte Sprachen](#unterstützte-sprachen)
 - [Installationsanleitung](#installationsanleitung)
+  - [Einfachste Installationsmethode (PowerShell)](#einfachste-installationsmethode-powershell)
+  - [Automatische Installation (Alternative)](#automatische-installation-alternative)
+  - [Manuelle Installation](#manuelle-installation)
+    - [Beispiel `user.cfg` Datei:](#beispiel-usercfg-datei)
 - [Aktualisieren der Lokalisierungsdateien](#aktualisieren-der-lokalisierungsdateien)
 - [Beitragen](#beitragen)
+- [Mitwirkende](#mitwirkende)
+- [Statistik](#statistik)
 - [Haftungsausschluss](#haftungsausschluss)
 
 ---
@@ -33,7 +39,7 @@
 | Französisch - Frankreich | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Generiert von [circuspes.fr](https://traduction.circuspes.fr) |
 | Deutsch - Deutschland   | ![Static Badge](https://img.shields.io/badge/4.2.0-LIVE-orange) | Hier |
 | Portugiesisch - Brasilien| ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Hier |
-| Italienisch - Italien   | ![Static Badge](https://img.shields.io/badge/4.7.2-LIVE-yellow) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) und [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
+| Italienisch - Italien   | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) und [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
 | Spanisch - Spanien      | ![Static Badge](https://img.shields.io/badge/3.23.1a-LIVE-orange) | Hier |
 | Türkisch - Türkei       | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Hier |
 | Spanisch - Lateinamerika| ![Static Badge](https://img.shields.io/badge/x.xx.x-LIVE-darkred) | Warten auf Beitrag |

--- a/README_es.md
+++ b/README_es.md
@@ -1,4 +1,4 @@
-# StarCitizen-Localization 🌎
+# StarCitizen-Localization 🌎<!-- omit in toc -->
 
 [![Discord](https://img.shields.io/discord/1185135396112322620?logo=discord\&label=discord)](https://discord.gg/Gbvz9fTmZU)
 ![Descargas totales](https://img.shields.io/github/downloads/Dymerz/StarCitizen-Localization/total)
@@ -21,11 +21,17 @@
 
 **Tabla de Contenido:**
 
-- [Idiomas Soportados](#supported-languages)
-- [Guía de Instalación](#installation-guide)
-- [Actualización de Archivos de Localización](#contributing)
-- [Contribuir](#contributing)
-- [Descargo de Responsabilidad](#Disclaimer)
+- [Idiomas Soportados](#idiomas-soportados)
+- [Guía de Instalación](#guía-de-instalación)
+  - [Método Más Fácil (PowerShell)](#método-más-fácil-powershell)
+  - [Instalación Automática (Alternativa)](#instalación-automática-alternativa)
+  - [Instalación Manual](#instalación-manual)
+    - [Ejemplo de archivo `user.cfg`:](#ejemplo-de-archivo-usercfg)
+- [Actualización de Archivos de Localización](#actualización-de-archivos-de-localización)
+- [Contribuir](#contribuir)
+- [Contribuidores](#contribuidores)
+- [Analítica](#analítica)
+- [Descargo de Responsabilidad](#descargo-de-responsabilidad)
 
 ---
 
@@ -37,7 +43,7 @@
 | Francés - Francia       | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Generado desde [circuspes.fr](https://traduction.circuspes.fr) |
 | Alemán (Alemania)       | ![Static Badge](https://img.shields.io/badge/4.2.0-LIVE-orange)   | Aquí                                                                                                                                |
 | Portugués (Brasil)      | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen)   | Aquí                                                                                                                                |
-| Italiano (Italia)       | ![Static Badge](https://img.shields.io/badge/4.7.2-LIVE-yellow)    | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) y [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
+| Italiano (Italia)       | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen)    | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) y [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
 | Español (España)        | ![Static Badge](https://img.shields.io/badge/3.23.1a-LIVE-orange)  | Aquí                                                                                                                                |
 | Turco (Turquía)         | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Aquí                                                                                                                                |
 | Español (Latinoamérica) | ![Static Badge](https://img.shields.io/badge/x.xx.x-LIVE-darkred)   | Esperando contribución                                                                                                              |

--- a/README_fr.md
+++ b/README_fr.md
@@ -1,4 +1,4 @@
-# StarCitizen-Localization 🌎
+# StarCitizen-Localization 🌎<!-- omit in toc -->
 
 [![Discord](https://img.shields.io/discord/1185135396112322620?logo=discord&label=discord)](https://discord.gg/Gbvz9fTmZU)
 ![GitHub all releases](https://img.shields.io/github/downloads/Dymerz/StarCitizen-Localization/total)
@@ -19,11 +19,17 @@
 
 
 **Table des matières :**
-1. [Langues Prises en Charge](#langues-prises-en-charge)
-2. [Guide d'Installation](#guide-dinstallation)
-3. [Mise à Jour des Fichiers de Localisation](#mise-à-jour-des-fichiers-de-localisation)
-4. [Contribuer](#contribuer)
-5. [Avis de non-responsabilité](#avis-de-non-responsabilité)
+- [Langues Prises en Charge](#langues-prises-en-charge)
+- [Guide d'Installation](#guide-dinstallation)
+  - [Méthode d'Installation la Plus Simple (PowerShell)](#méthode-dinstallation-la-plus-simple-powershell)
+  - [Installation Automatique (Alternative)](#installation-automatique-alternative)
+  - [Installation manuelle](#installation-manuelle)
+    - [Exemple de fichier `user.cfg` :](#exemple-de-fichier-usercfg-)
+- [Mise à Jour des Fichiers de Localisation](#mise-à-jour-des-fichiers-de-localisation)
+- [Contribuer](#contribuer)
+- [Contributeurs](#contributeurs)
+- [Analytique](#analytique)
+- [Avis de non-responsabilité](#avis-de-non-responsabilité)
 
 ---
 ## Langues Prises en Charge
@@ -34,7 +40,7 @@
 | Français - France       | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Généré depuis [circuspes.fr](https://traduction.circuspes.fr) |
 | Allemand - Allemagne    | ![Static Badge](https://img.shields.io/badge/4.2.0-LIVE-orange) | Ici |
 | Portugais - Brésil      | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Ici |
-| Italien - Italie        | ![Static Badge](https://img.shields.io/badge/4.7.2-LIVE-yellow) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) et [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
+| Italien - Italie        | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) et [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
 | Espagnol - Espagne      | ![Static Badge](https://img.shields.io/badge/3.23.1a-LIVE-orange) | Ici |
 | Turc - Turquie          | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Ici |
 | Espagnol - Amérique latine | ![Static Badge](https://img.shields.io/badge/x.xx.x-LIVE-darkred) | En attente de contribution |

--- a/README_it.md
+++ b/README_it.md
@@ -1,4 +1,4 @@
-# StarCitizen-Localization 🌎
+# StarCitizen-Localization 🌎<!-- omit in toc -->
 
 [![Discord](https://img.shields.io/discord/1185135396112322620?logo=discord&label=discord)](https://discord.gg/Gbvz9fTmZU)
 ![GitHub all releases](https://img.shields.io/github/downloads/Dymerz/StarCitizen-Localization/total)
@@ -18,12 +18,17 @@
 - 🇹🇷 [Türkçe Talimatlar](README_tr.md).
 
 **Tabella dei contenuti:**
-- [Lingue supportate](#lingue-supportate)
+- [Lingue Supportate](#lingue-supportate)
 - [Installazione](#installazione)
-- [Aggiornare i file di localizzazione](#aggiornamenti)
-- [Come contribuire alla localizzazione](#contribuire)
-- [Contributori](#contributors)
-- [Disclaimer](#Disclaimer)
+  - [Metodo di Installazione Più Semplice (PowerShell)](#metodo-di-installazione-più-semplice-powershell)
+  - [Installazione Automatica (Alternativa)](#installazione-automatica-alternativa)
+  - [Installazione Manuale](#installazione-manuale)
+    - [Esempio di file `user.cfg`:](#esempio-di-file-usercfg)
+- [Aggiornamenti](#aggiornamenti)
+- [Contribuire](#contribuire)
+- [Contributori](#contributori)
+- [Analisi](#analisi)
+- [Disclaimer](#disclaimer)
 
 ---
 ## Lingue Supportate
@@ -34,7 +39,7 @@
 | Francese - Francia      | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Generato da [circuspes.fr](https://traduction.circuspes.fr) |
 | Tedesco - Germania      | ![Static Badge](https://img.shields.io/badge/4.2.0-LIVE-orange) | Qui |
 | Portoghese - Brasile    | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Qui |
-| Italiano - Italia       | ![Static Badge](https://img.shields.io/badge/4.7.2-LIVE-yellow) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) e [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
+| Italiano - Italia       | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) e [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
 | Spagnolo - Spagna       | ![Static Badge](https://img.shields.io/badge/3.23.1a-LIVE-orange) | Qui |
 | Turco - Turchia         | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Qui |
 | Spagnolo - America Latina | ![Static Badge](https://img.shields.io/badge/x.xx.x-LIVE-darkred) | In attesa di contributo |

--- a/README_ptbr.md
+++ b/README_ptbr.md
@@ -1,4 +1,4 @@
-# StarCitizen-Localization 🌎
+# StarCitizen-Localization 🌎<!-- omit in toc -->
 
 [![Discord](https://img.shields.io/discord/1185135396112322620?logo=discord&label=discord)](https://discord.gg/Gbvz9fTmZU)
 ![GitHub all releases](https://img.shields.io/github/downloads/Dymerz/StarCitizen-Localization/total)
@@ -33,7 +33,7 @@
 | Francês - França        | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Gerado de [circuspes.fr](https://traduction.circuspes.fr) |
 | Alemão - Alemanha       | ![Static Badge](https://img.shields.io/badge/4.2.0-LIVE-orange) | Aqui |
 | Português - Brasil      | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Aqui |
-| Italiano - Itália       | ![Static Badge](https://img.shields.io/badge/4.7.2-LIVE-yellow) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) e [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
+| Italiano - Itália       | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) e [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
 | Espanhol - Espanha      | ![Static Badge](https://img.shields.io/badge/3.23.1a-LIVE-orange) | Aqui |
 | Turco - Turquia         | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Aqui |
 | Espanhol - América Latina | ![Static Badge](https://img.shields.io/badge/x.xx.x-LIVE-darkred) | Aguardando contribuição |

--- a/README_tr.md
+++ b/README_tr.md
@@ -1,4 +1,4 @@
-# StarCitizen-Localization 🌍
+# StarCitizen-Localization 🌍<!-- omit in toc -->
 
 [![Discord](https://img.shields.io/discord/1185135396112322620?logo=discord&label=discord)](https://discord.gg/Gbvz9fTmZU)
 ![GitHub all releases](https://img.shields.io/github/downloads/Dymerz/StarCitizen-Localization/total)
@@ -20,6 +20,10 @@
 **Içindekiler:**
 - [Desteklenen Diller](#desteklenen-diller)
 - [Kurulum Rehberi](#kurulum-rehberi)
+  - [En Kolay Kurulum Yöntemi (PowerShell)](#en-kolay-kurulum-yöntemi-powershell)
+  - [Otomatik Kurulum (Alternatif)](#otomatik-kurulum-alternatif)
+  - [Manuel Kurulum](#manuel-kurulum)
+    - [Diger Diller Için Yapilandirma](#diger-diller-için-yapilandirma)
 - [Yerellestirme Dosyalarini Güncelleme](#yerellestirme-dosyalarini-güncelleme)
 - [Katkida Bulunma](#katkida-bulunma)
 - [Sorumluluk Reddi](#sorumluluk-reddi)
@@ -33,7 +37,7 @@
 | Fransizca - Fransa       | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | [circuspes.fr](https://traduction.circuspes.fr) üzerinden olusturuldu |
 | Almanca - Almanya        | ![Static Badge](https://img.shields.io/badge/4.2.0-LIVE-orange) | Burada |
 | Portekizce - Brezilya    | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen | Burada |
-| Italyanca - Italya       | ![Static Badge](https://img.shields.io/badge/4.7.2-LIVE-yellow) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) ve [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
+| Italyanca - Italya       | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) ve [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
 | Ispanyolca - Ispanya     | ![Static Badge](https://img.shields.io/badge/3.23.1a-LIVE-orange) | Burada |
 | Türkçe - Türkiye         | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Burada |
 | Ispanyolca - Latin Amerika| ![Static Badge](https://img.shields.io/badge/x.xx.x-LIVE-darkred) | Katki bekleniyor |


### PR DESCRIPTION
Add "<!-- omit in toc -->" to top headings and expand table-of-contents across README translations (EN, DE, ES, FR, IT, PT-BR, TR). New TOC items include easiest/automatic/manual installation steps (with example user.cfg), Contributors and Analytics sections. Standardize Italian badge/version to 4.8.0 and adjust badge coloring for consistency, plus minor formatting fixes.