### PR TITLE
Bump localization badges to 4.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@
 
 | Language                 | Supported | Source |
 |--------------------------|-----------|--------|
-| English                  | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Imported from game files |
-| French - France          | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Generated from [circuspes.fr](https://traduction.circuspes.fr) |
+| English                  | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen) | Imported from game files |
+| French - France          | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen) | Generated from [circuspes.fr](https://traduction.circuspes.fr) |
 | German - Germany         | ![Static Badge](https://img.shields.io/badge/4.2.0-LIVE-orange) | Here |
-| Portuguese - Brazil      | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Here |
-| Italian - Italy          | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) and [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
+| Portuguese - Brazil      | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen) | Here |
+| Italian - Italy          | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) and [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
 | Spanish - Spain          | ![Static Badge](https://img.shields.io/badge/3.23.1a-LIVE-orange) | Here |
 | Turkish - Turkey         | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Here |
 | Spanish - Latin America  | ![Static Badge](https://img.shields.io/badge/x.xx.x-LIVE-darkred) | Awaiting contribution |

--- a/README_de.md
+++ b/README_de.md
@@ -35,11 +35,11 @@
 
 | Sprache                 | Unterstützt | Quelle |
 |--------------------------|-------------|--------|
-| Englisch                | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Aus Spieldateien importiert |
-| Französisch - Frankreich | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Generiert von [circuspes.fr](https://traduction.circuspes.fr) |
+| Englisch                | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen) | Aus Spieldateien importiert |
+| Französisch - Frankreich | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen) | Generiert von [circuspes.fr](https://traduction.circuspes.fr) |
 | Deutsch - Deutschland   | ![Static Badge](https://img.shields.io/badge/4.2.0-LIVE-orange) | Hier |
-| Portugiesisch - Brasilien| ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Hier |
-| Italienisch - Italien   | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) und [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
+| Portugiesisch - Brasilien| ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen) | Hier |
+| Italienisch - Italien   | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) und [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
 | Spanisch - Spanien      | ![Static Badge](https://img.shields.io/badge/3.23.1a-LIVE-orange) | Hier |
 | Türkisch - Türkei       | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Hier |
 | Spanisch - Lateinamerika| ![Static Badge](https://img.shields.io/badge/x.xx.x-LIVE-darkred) | Warten auf Beitrag |

--- a/README_es.md
+++ b/README_es.md
@@ -39,11 +39,11 @@
 
 | Idioma                  | Soporte                                                            | Fuente                                                                                                                              |
 | ----------------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
-| Inglés                  | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen)   | Importado de archivos del juego                                                                                                     |
-| Francés - Francia       | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Generado desde [circuspes.fr](https://traduction.circuspes.fr) |
+| Inglés                  | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen)   | Importado de archivos del juego                                                                                                     |
+| Francés - Francia       | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen) | Generado desde [circuspes.fr](https://traduction.circuspes.fr) |
 | Alemán (Alemania)       | ![Static Badge](https://img.shields.io/badge/4.2.0-LIVE-orange)   | Aquí                                                                                                                                |
-| Portugués (Brasil)      | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen)   | Aquí                                                                                                                                |
-| Italiano (Italia)       | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen)    | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) y [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
+| Portugués (Brasil)      | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen)   | Aquí                                                                                                                                |
+| Italiano (Italia)       | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen)    | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) y [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
 | Español (España)        | ![Static Badge](https://img.shields.io/badge/3.23.1a-LIVE-orange)  | Aquí                                                                                                                                |
 | Turco (Turquía)         | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Aquí                                                                                                                                |
 | Español (Latinoamérica) | ![Static Badge](https://img.shields.io/badge/x.xx.x-LIVE-darkred)   | Esperando contribución                                                                                                              |

--- a/README_fr.md
+++ b/README_fr.md
@@ -36,11 +36,11 @@
 
 | Langue                  | Pris en charge | Source |
 |--------------------------|----------------|--------|
-| Anglais                 | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Importé des fichiers du jeu |
-| Français - France       | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Généré depuis [circuspes.fr](https://traduction.circuspes.fr) |
+| Anglais                 | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen) | Importé des fichiers du jeu |
+| Français - France       | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen) | Généré depuis [circuspes.fr](https://traduction.circuspes.fr) |
 | Allemand - Allemagne    | ![Static Badge](https://img.shields.io/badge/4.2.0-LIVE-orange) | Ici |
-| Portugais - Brésil      | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Ici |
-| Italien - Italie        | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) et [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
+| Portugais - Brésil      | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen) | Ici |
+| Italien - Italie        | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) et [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
 | Espagnol - Espagne      | ![Static Badge](https://img.shields.io/badge/3.23.1a-LIVE-orange) | Ici |
 | Turc - Turquie          | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Ici |
 | Espagnol - Amérique latine | ![Static Badge](https://img.shields.io/badge/x.xx.x-LIVE-darkred) | En attente de contribution |

--- a/README_it.md
+++ b/README_it.md
@@ -35,11 +35,11 @@
 
 | Lingua                  | Supportato | Fonte |
 |--------------------------|------------|-------|
-| Inglese                 | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Importato dai file di gioco |
-| Francese - Francia      | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Generato da [circuspes.fr](https://traduction.circuspes.fr) |
+| Inglese                 | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen) | Importato dai file di gioco |
+| Francese - Francia      | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen) | Generato da [circuspes.fr](https://traduction.circuspes.fr) |
 | Tedesco - Germania      | ![Static Badge](https://img.shields.io/badge/4.2.0-LIVE-orange) | Qui |
-| Portoghese - Brasile    | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Qui |
-| Italiano - Italia       | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) e [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
+| Portoghese - Brasile    | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen) | Qui |
+| Italiano - Italia       | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) e [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
 | Spagnolo - Spagna       | ![Static Badge](https://img.shields.io/badge/3.23.1a-LIVE-orange) | Qui |
 | Turco - Turchia         | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Qui |
 | Spagnolo - America Latina | ![Static Badge](https://img.shields.io/badge/x.xx.x-LIVE-darkred) | In attesa di contributo |

--- a/README_ptbr.md
+++ b/README_ptbr.md
@@ -29,11 +29,11 @@
 
 | Idioma                  | Suportado | Fonte |
 |--------------------------|-----------|-------|
-| Inglês                  | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Importado dos arquivos do jogo |
-| Francês - França        | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Gerado de [circuspes.fr](https://traduction.circuspes.fr) |
+| Inglês                  | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen) | Importado dos arquivos do jogo |
+| Francês - França        | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen) | Gerado de [circuspes.fr](https://traduction.circuspes.fr) |
 | Alemão - Alemanha       | ![Static Badge](https://img.shields.io/badge/4.2.0-LIVE-orange) | Aqui |
-| Português - Brasil      | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Aqui |
-| Italiano - Itália       | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) e [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
+| Português - Brasil      | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen) | Aqui |
+| Italiano - Itália       | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) e [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
 | Espanhol - Espanha      | ![Static Badge](https://img.shields.io/badge/3.23.1a-LIVE-orange) | Aqui |
 | Turco - Turquia         | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Aqui |
 | Espanhol - América Latina | ![Static Badge](https://img.shields.io/badge/x.xx.x-LIVE-darkred) | Aguardando contribuição |

--- a/README_tr.md
+++ b/README_tr.md
@@ -33,11 +33,11 @@
 
 | Dil                      | Durum | Kaynak |
 |--------------------------|-------|--------|
-| Ingilizce                | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | Oyun dosyalarindan içe aktarildi |
-| Fransizca - Fransa       | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | [circuspes.fr](https://traduction.circuspes.fr) üzerinden olusturuldu |
+| Ingilizce                | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen) | Oyun dosyalarindan içe aktarildi |
+| Fransizca - Fransa       | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen) | [circuspes.fr](https://traduction.circuspes.fr) üzerinden olusturuldu |
 | Almanca - Almanya        | ![Static Badge](https://img.shields.io/badge/4.2.0-LIVE-orange) | Burada |
-| Portekizce - Brezilya    | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen | Burada |
-| Italyanca - Italya       | ![Static Badge](https://img.shields.io/badge/4.8.0-LIVE-brightgreen) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) ve [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
+| Portekizce - Brezilya    | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen | Burada |
+| Italyanca - Italya       | ![Static Badge](https://img.shields.io/badge/4.8.1-LIVE-brightgreen) | [GattoMatto](https://robertsspaceindustries.com/citizens/GattoMatto) ve [MrRevo](https://robertsspaceindustries.com/citizens/MrRevo) |
 | Ispanyolca - Ispanya     | ![Static Badge](https://img.shields.io/badge/3.23.1a-LIVE-orange) | Burada |
 | Türkçe - Türkiye         | ![Static Badge](https://img.shields.io/badge/4.6.0-LIVE-yellow) | Burada |
 | Ispanyolca - Latin Amerika| ![Static Badge](https://img.shields.io/badge/x.xx.x-LIVE-darkred) | Katki bekleniyor |


### PR DESCRIPTION
Update version badges from 4.8.0 to 4.8.1 in the main README and localized READMEs to reflect the new release. Files updated: README.md, README_de.md, README_es.md, README_fr.md, README_it.md, README_ptbr.md, README_tr.md. Changes affect English, French, Portuguese (BR) and Italian entries.

No changes in english global.ini